### PR TITLE
Poc admin interface

### DIFF
--- a/unified-codes/apps/data-service/src/app/v1/types/DgraphClientDataSource.ts
+++ b/unified-codes/apps/data-service/src/app/v1/types/DgraphClientDataSource.ts
@@ -1,0 +1,231 @@
+import { IProperty } from '@unified-codes/data/v1';
+import { DataSource } from 'apollo-datasource';
+import dgraph, { grpc } from 'dgraph-js';
+
+export class DgraphClientDataSource extends DataSource {
+  private dgraph: DgraphClient;
+
+  constructor() {
+    super();
+    this.dgraph = new DgraphClient('localhost', '9080');
+  }
+  // ----- UPDATE ENTITY
+  // dg.updateEntityGRPCNQuads('c7750233', {
+  //   name: 'Abacavir',
+  // });
+  async updateEntityGRPCNQuads(code: string, patch: { [key: string]: any }) {
+    const query = `
+      query {
+        Entity as var(func: eq(code, "${code}"))
+      }
+  `;
+
+    // only run the mutation if the Entity exists!
+    const condition = '@if(eq(len(Entity), 1))';
+
+    const nQuadRows = [];
+    for (const key in patch) {
+      nQuadRows.push(`uid(Entity) <${key}> "${patch[key]}" .`);
+    }
+    const nQuads = nQuadRows.join('\n');
+
+    await this.dgraph.upsert(query, nQuads, condition);
+
+    // OR, AS JSON (simpler)
+    // -
+    // const json = {
+    //   ...patch,
+    //   uid: 'uid(Entity)',
+    // };
+
+    // await this.dgraph.upsertJson(query, json, condition);
+  }
+
+  // ------ ADD PROPERTY
+  // dg.addPropertyToEntityGRPCNQuads('abc12345', {
+  //   value: 'New Property!',
+  //   type: 'code_rxnav',
+  // });
+  // Not idempotent... maybe antoher query first?
+  async addPropertyToEntityGRPCNQuads(drugCode: string, property: IProperty) {
+    const query = `
+      query {
+        Entity as var(func: eq(code, "${drugCode}"))
+      }
+  `;
+
+    const nQuads = `
+  _:property <value> "${property.value}" .
+  _:property <dgraph.type> "${property.type}" .
+
+  uid(Entity) <properties> _:property .
+`;
+
+    const condition = '@if(eq(len(Entity), 1))';
+    await this.dgraph.upsert(query, nQuads, condition);
+
+    // NOT SURE HOW TO DO THE JSON VERSION OF THIS YET... this is making `properties` null lol
+    // const json = {
+    //   uid: 'uid(Entity)',
+    //   properties: {
+    //     ...property,
+    //     uid: '_:property',
+    //   },
+    // };
+  }
+
+  // ------ ADD PROPERTY
+  // dg.addEntityGRPCNQuads('abc12346', {
+  //   name: 'Shiny new route',
+  //   code: 'abc12356',
+  //   type: 'Route',
+  // });
+
+  // wouldn't work to add a category but that would be rare/never
+  // this is idempotent... somehow
+  async addEntityGRPCNQuads(
+    parentCode: string,
+    entity: {
+      name: string;
+      code: string;
+      type: string;
+    }
+  ) {
+    const query = `
+      query {
+        Parent as var(func: eq(code, "${parentCode}"))
+        Entity as var(func: eq(code, "${entity.code}"))
+      }
+  `;
+
+    // maybe would want to be able to add an optional combines here, if we have already entered the product it would combine with..
+    const nQuads = `
+      uid(Entity) <name> "${entity.name}" .
+      uid(Entity) <code> "${entity.code}" .
+      uid(Entity) <dgraph.type> "${entity.type}" .
+
+      uid(Parent) <children> uid(Entity) .
+    `;
+
+    await this.dgraph.upsert(query, nQuads);
+  }
+
+  // TODO: not working yet... it might be deleting the node but not the linkings?
+  // async deleteEntityGRPCNQuads(code: string) {
+  //   const query = `
+  //       query {
+  //         Entity as var(func: eq(code, "${code}"))
+  //       }
+  //   `;
+
+  //   const nQuads = `uid(Entity) * * .`;
+
+  //   await this.dgraph.delete(query, nQuads);
+  // }
+}
+
+class DgraphClient {
+  public readonly host: string;
+  public readonly port: string;
+
+  private readonly stub: dgraph.DgraphClientStub;
+  private readonly client: dgraph.DgraphClient;
+
+  constructor(host: string, port: string) {
+    this.host = host;
+    this.port = port;
+
+    this.stub = new dgraph.DgraphClientStub(
+      `${this.host}:${this.port}`,
+      grpc.credentials.createInsecure()
+    );
+    this.client = new dgraph.DgraphClient(this.stub);
+  }
+
+  async mutate(nQuads: string, commitNow = true) {
+    const mutation: dgraph.Mutation = new dgraph.Mutation();
+    mutation.setSetNquads(nQuads);
+
+    const request: dgraph.Request = new dgraph.Request();
+    request.setCommitNow(commitNow);
+    request.setMutationsList([mutation]);
+
+    const txn: dgraph.Txn = this.client.newTxn();
+
+    try {
+      await txn.doRequest(request);
+      txn.discard();
+      return true;
+    } catch {
+      txn.discard();
+      return false;
+    }
+  }
+
+  async upsert(query: string, nQuads: string, condition = '', commitNow = true) {
+    const mutation = new dgraph.Mutation();
+    mutation.setSetNquads(nQuads);
+    mutation.setCond(condition);
+
+    const request = new dgraph.Request();
+    request.setCommitNow(commitNow);
+    request.setMutationsList([mutation]);
+
+    request.setQuery(query);
+
+    const txn: dgraph.Txn = this.client.newTxn();
+
+    try {
+      await txn.doRequest(request);
+      txn.discard();
+      return true;
+    } catch (e) {
+      txn.discard();
+      return false;
+    }
+  }
+
+  async upsertJson(query, json: any, condition = '', commitNow = true) {
+    const mutation = new dgraph.Mutation();
+    mutation.setSetJson(json);
+    mutation.setCond(condition);
+
+    const request = new dgraph.Request();
+    request.setCommitNow(commitNow);
+    request.setMutationsList([mutation]);
+
+    request.setQuery(query);
+
+    const txn: dgraph.Txn = this.client.newTxn();
+
+    try {
+      await txn.doRequest(request);
+      txn.discard();
+      return true;
+    } catch (e) {
+      txn.discard();
+      return false;
+    }
+  }
+
+  async delete(query: string, nQuads: string) {
+    const mutation = new dgraph.Mutation();
+    mutation.setDelNquads(nQuads);
+
+    const request = new dgraph.Request();
+    request.setMutationsList([mutation]);
+
+    request.setQuery(query);
+
+    const txn = this.client.newTxn();
+
+    try {
+      await txn.doRequest(request);
+      txn.discard();
+      return true;
+    } catch (e) {
+      txn.discard();
+      return false;
+    }
+  }
+}

--- a/unified-codes/apps/data-service/src/app/v1/types/DgraphDataSource.ts
+++ b/unified-codes/apps/data-service/src/app/v1/types/DgraphDataSource.ts
@@ -79,7 +79,7 @@ export class DgraphDataSource extends RESTDataSource {
       query(func: eq(code, ${code?.toLowerCase()}), first:1) @recurse(loop:false) {
         code
         type: dgraph.type
-        description: name@*
+        description: name
         value
         combines
         children
@@ -94,7 +94,7 @@ export class DgraphDataSource extends RESTDataSource {
       query (func: eq(dgraph.type, "Product")) @cascade {
         code
         type: dgraph.type
-        description: name@*
+        description: name
         properties {
           type: dgraph.type
           value

--- a/unified-codes/apps/web/src/sagas/AuthenticatorSaga.ts
+++ b/unified-codes/apps/web/src/sagas/AuthenticatorSaga.ts
@@ -28,7 +28,7 @@ function* authenticate(action: IAuthenticateAction) {
   try {
     const identityProvider: IdentityProvider = new KeyCloakIdentityProvider(keycloakConfig);
     const authenticator: AuthenticationService = new AuthenticationService(identityProvider);
-    const user: User = yield call(authenticator.login, credentials);
+    const user: User = yield call(authenticator.login.bind(authenticator), credentials);
     yield put(AuthenticatorActions.authenticationSuccess(user));
   } catch (error) {
     yield put(AuthenticatorActions.authenticationFailure(error.messages));

--- a/unified-codes/data/v2/schema.graphql
+++ b/unified-codes/data/v2/schema.graphql
@@ -1,0 +1,55 @@
+interface Entity {
+  id: ID!
+  code: String @dgraph(pred: "code") @search
+  description: String @dgraph(pred: "name")
+  properties: [Property] @dgraph(pred: "properties")
+  # children: [Entity] @dgraph(pred: "children")
+  children: [Entity] @hasInverse(field: parent) @dgraph(pred: "children")
+  parent: Entity
+}
+
+type Category implements Entity
+type Route implements Entity
+type Form implements Entity # DoseForm
+type FormQualifier implements Entity # DoseFormQualifier
+type DoseStrength implements Entity
+type Unit implements Entity #DoseUnit
+type PackImmediate implements Entity
+type PackSize implements Entity
+
+type Product implements Entity {
+  combines: [Product]
+  # children: [Route] @hasInverse(field: parent) @dgraph(pred: "children")
+  # parent: Category
+}
+# type Category implements Entity {
+#   children: [Product] @hasInverse(field: parent) @dgraph(pred: "children")
+# }
+# type Route implements Entity {
+#   children: [Form] @hasInverse(field: parent) @dgraph(pred: "children")
+#   parent: Product
+# }
+# type Form implements Entity { # DoseForm
+#   parent: Route
+# }
+
+# Unfortunately we can't have unions here... started experimenting with the above, defining the child/parent types - this creates a stricter hierarchy...
+# union EntityType =
+#     Category
+#   | Product
+#   | Form
+#   | FormQualifier
+#   | DoseStrength
+#   | Unit
+#   | PackImmediate
+#   | PackSize
+
+interface Property {
+  id: ID!
+  value: String @dgraph(pred: "value")
+}
+
+type who_eml implements Property
+type code_nzulm implements Property
+type code_rxnav implements Property
+type code_unspsc implements Property


### PR DESCRIPTION
DONT MERGE ME! 

## Description
<!--- Briefly describe your changes -->

Some playing around with the dgraph-js client library (slight abstraction over the raw DQL, but really not much 😢)

Finally realised hitting DGraph's `/graphql` endpoint will be the way to go - once in code we should probably use Apollo Client to call it.

We can manage DGraph's schema via a graphQL schema (it gets translated into DQL). I was messing with the schema in `unified-codes/data/v2/schema.graphql`, and uploading it to dgraph by running the following from the same `v2` directory (though we should perhaps put said schema file somewhere else?):

```
curl -X POST localhost:8080/admin/schema --data-binary '@schema.graphql'
```

Once you define these types, the DGraph/GraphQL integration does most of the heavy lifting, and creates the necessary mutations/queries [from those types](https://dgraph.io/docs/graphql/schema/reserved/)

It's a little finicky trying to line up the existing DQL schema to the graphQL schema... perhaps we should ignore this and build from the ground up with the GraphQL schema, seeing as we're putting the DataLoader code out of a job, and we should probably migrate the existing queries from DQL to GraphQL anyway. We have our own GraphQL API contract to build to, which should give us all the requirements we need. 

The relationships as we've built them with DQL don't translate perfectly to GraphQL, so if we consider it important to keep what we already have, there will be a bit of work getting them to line up, though I made good progress on it in this PR.

