### PR TITLE
Graphql dgraph

### DIFF
--- a/frontend/packages/common/src/api/GqlContext.tsx
+++ b/frontend/packages/common/src/api/GqlContext.tsx
@@ -118,7 +118,8 @@ export const createGql = (
   url: string,
   skipRequest?: SkipRequest
 ): { client: GQLClient } => {
-  const client = new GQLClient(url, { credentials: 'include' }, skipRequest);
+  const client = new GQLClient(url, { credentials: 'omit' }, skipRequest);
+  // const client = new GQLClient(url, { credentials: 'include' }, skipRequest);
   return { client };
 };
 

--- a/frontend/packages/common/src/types/schema.ts
+++ b/frontend/packages/common/src/types/schema.ts
@@ -108,6 +108,7 @@ export type Query = {
   __typename: 'Query';
   entities: EntityCollectionType;
   entity?: Maybe<EntityType>;
+  entity2?: Maybe<EntityType>;
   interactions: DrugInteractionsType;
 };
 
@@ -120,6 +121,11 @@ export type QueryEntitiesArgs = {
 
 
 export type QueryEntityArgs = {
+  code: Scalars['String']['input'];
+};
+
+
+export type QueryEntity2Args = {
   code: Scalars['String']['input'];
 };
 

--- a/frontend/packages/host/src/Admin/Settings.tsx
+++ b/frontend/packages/host/src/Admin/Settings.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {
+  Box,
   Grid,
   TranslateIcon,
   Typography,
@@ -10,10 +11,12 @@ import { LanguageMenu } from '../components';
 import { Setting } from './Setting';
 import { Environment } from '@uc-frontend/config';
 import { useHost } from '../api/hooks';
+import { useEntity } from '../api/hooks/utils/useEntity';
 
 export const Settings: React.FC = () => {
   const t = useTranslation('host');
-  const { data } = useHost.utils.version();
+  const { data: version } = useHost.utils.version();
+  const { data: entity } = useEntity('c7750265');
 
   return (
     <Grid
@@ -31,6 +34,10 @@ export const Settings: React.FC = () => {
         title={t('button.language')}
         icon={<TranslateIcon />}
       />
+      <Typography variant="h5" color="primary" style={{ paddingBottom: 25 }}>
+        Entity Query
+      </Typography>
+      <Entity entity={entity} />
       <Grid style={{ position: 'absolute', right: 0, bottom: 30 }}>
         <Grid container padding={1} flexDirection="column">
           <Grid item display="flex" flex={1} gap={1}>
@@ -43,7 +50,7 @@ export const Settings: React.FC = () => {
               <Typography>{Environment.BUILD_VERSION}</Typography>
             </Grid>
           </Grid>
-          {!!data && (
+          {!!version && (
             <Grid item display="flex" flex={1} gap={1}>
               <Grid item justifyContent="flex-end" flex={1} display="flex">
                 <Typography fontWeight={700} whiteSpace="nowrap">
@@ -51,12 +58,47 @@ export const Settings: React.FC = () => {
                 </Typography>
               </Grid>
               <Grid item flex={1}>
-                <Typography>{data}</Typography>
+                <Typography>{version}</Typography>
               </Grid>
             </Grid>
           )}
         </Grid>
       </Grid>
     </Grid>
+  );
+};
+
+type IEntity = {
+  description?: string | null;
+  code: string;
+  children?: IEntity[] | null;
+  properties?:
+    | {
+        type: string;
+        value: string;
+      }[]
+    | null;
+};
+
+const Entity = ({ entity }: { entity?: IEntity | null }) => {
+  return (
+    <Box paddingLeft={'10px'}>
+      <Typography>
+        {entity?.description} ({entity?.code})
+      </Typography>
+      {entity?.children?.map(c => (
+        <Entity entity={c} key={c.code} />
+      ))}
+      {entity?.properties && (
+        <>
+          <Typography fontWeight={700}>Properties</Typography>
+          {entity.properties.map(p => (
+            <Typography key={p.value}>
+              {p.type}: {p.value}
+            </Typography>
+          ))}
+        </>
+      )}
+    </Box>
   );
 };

--- a/frontend/packages/host/src/Admin/Settings.tsx
+++ b/frontend/packages/host/src/Admin/Settings.tsx
@@ -35,7 +35,7 @@ export const Settings: React.FC = () => {
         icon={<TranslateIcon />}
       />
       <Typography variant="h5" color="primary" style={{ paddingBottom: 25 }}>
-        Entity Query
+        Entity Query (c7750265)
       </Typography>
       <Entity entity={entity} />
       <Grid style={{ position: 'absolute', right: 0, bottom: 30 }}>

--- a/frontend/packages/host/src/api/api.ts
+++ b/frontend/packages/host/src/api/api.ts
@@ -10,7 +10,7 @@ export const getHostQueries = (sdk: Sdk) => ({
     },
     entity: async (code: string) => {
       const result = await sdk.entity({ code });
-      return result.entity;
+      return result.entity2;
     },
   },
 });

--- a/frontend/packages/host/src/api/api.ts
+++ b/frontend/packages/host/src/api/api.ts
@@ -8,5 +8,9 @@ export const getHostQueries = (sdk: Sdk) => ({
       // return result.apiVersion;
       return 'v1';
     },
+    entity: async (code: string) => {
+      const result = await sdk.entity({ code });
+      return result.entity;
+    },
   },
 });

--- a/frontend/packages/host/src/api/hooks/utils/useEntity.ts
+++ b/frontend/packages/host/src/api/hooks/utils/useEntity.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@uc-frontend/common';
+import { useHostApi } from './useHostApi';
+
+export const useEntity = (code: string) => {
+  const api = useHostApi();
+  return useQuery(
+    api.keys.entity(code),
+    () => api.get.entity(code),
+    // Don't refetch on open. But, don't cache data when this query
+    // is inactive. For example, when navigating away from the page and back again, refetch.
+    {
+      refetchOnMount: false,
+      cacheTime: 0,
+    }
+  );
+};

--- a/frontend/packages/host/src/api/hooks/utils/useHostApi.ts
+++ b/frontend/packages/host/src/api/hooks/utils/useHostApi.ts
@@ -7,6 +7,7 @@ export const useHostApi = () => {
     base: () => ['host'] as const,
     version: () => [...keys.base(), 'version'] as const,
     settings: () => [...keys.base(), 'settings'] as const,
+    entity: (code: string) => [...keys.base(), 'entity', code] as const,
   };
 
   const { client } = useGql();

--- a/frontend/packages/host/src/api/operations.generated.ts
+++ b/frontend/packages/host/src/api/operations.generated.ts
@@ -8,12 +8,12 @@ export type EntityQueryVariables = Types.Exact<{
 }>;
 
 
-export type EntityQuery = { __typename: 'Query', entity?: { __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null, children?: Array<{ __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null, children?: Array<{ __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null, children?: Array<{ __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null, children?: Array<{ __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null, children?: Array<{ __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null }> | null }> | null }> | null }> | null }> | null } | null };
+export type EntityQuery = { __typename: 'Query', entity2?: { __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null, children?: Array<{ __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null, children?: Array<{ __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null, children?: Array<{ __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null, children?: Array<{ __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null, children?: Array<{ __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null }> | null }> | null }> | null }> | null }> | null } | null };
 
 
 export const EntityDocument = gql`
     query entity($code: String!) {
-  entity(code: $code) {
+  entity2(code: $code) {
     code
     description
     type

--- a/frontend/packages/host/src/api/operations.generated.ts
+++ b/frontend/packages/host/src/api/operations.generated.ts
@@ -3,47 +3,83 @@ import * as Types from '@uc-frontend/common';
 import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
-export type ApiVersionQueryVariables = Types.Exact<{ [key: string]: never }>;
+export type EntityQueryVariables = Types.Exact<{
+  code: Types.Scalars['String']['input'];
+}>;
 
-export type ApiVersionQuery = { __typename: 'FullQuery'; apiVersion: string };
 
-export const ApiVersionDocument = gql`
-  query apiVersion {
-    apiVersion
+export type EntityQuery = { __typename: 'Query', entity?: { __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null, children?: Array<{ __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null, children?: Array<{ __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null, children?: Array<{ __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null, children?: Array<{ __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null, children?: Array<{ __typename: 'EntityType', code: string, description?: string | null, type: string, properties?: Array<{ __typename: 'PropertyType', type: string, value: string }> | null }> | null }> | null }> | null }> | null }> | null } | null };
+
+
+export const EntityDocument = gql`
+    query entity($code: String!) {
+  entity(code: $code) {
+    code
+    description
+    type
+    properties {
+      type
+      value
+    }
+    children {
+      code
+      description
+      type
+      properties {
+        type
+        value
+      }
+      children {
+        code
+        description
+        type
+        properties {
+          type
+          value
+        }
+        children {
+          code
+          description
+          type
+          properties {
+            type
+            value
+          }
+          children {
+            code
+            description
+            type
+            properties {
+              type
+              value
+            }
+            children {
+              code
+              description
+              type
+              properties {
+                type
+                value
+              }
+            }
+          }
+        }
+      }
+    }
   }
-`;
+}
+    `;
 
-export type SdkFunctionWrapper = <T>(
-  action: (requestHeaders?: Record<string, string>) => Promise<T>,
-  operationName: string,
-  operationType?: string
-) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (
-  action,
-  _operationName,
-  _operationType
-) => action();
 
-export function getSdk(
-  client: GraphQLClient,
-  withWrapper: SdkFunctionWrapper = defaultWrapper
-) {
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType) => action();
+
+export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    apiVersion(
-      variables?: ApiVersionQueryVariables,
-      requestHeaders?: Dom.RequestInit['headers']
-    ): Promise<ApiVersionQuery> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<ApiVersionQuery>(ApiVersionDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'apiVersion',
-        'query'
-      );
-    },
+    entity(variables: EntityQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<EntityQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<EntityQuery>(EntityDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'entity', 'query');
+    }
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;

--- a/frontend/packages/host/src/api/operations.graphql
+++ b/frontend/packages/host/src/api/operations.graphql
@@ -3,7 +3,7 @@
 # }
 
 query entity($code: String!) {
-  entity(code: $code) {
+  entity2(code: $code) {
     code
     description
     type

--- a/frontend/packages/host/src/api/operations.graphql
+++ b/frontend/packages/host/src/api/operations.graphql
@@ -1,3 +1,60 @@
-query apiVersion {
-  apiVersion
+# query apiVersion {
+#   apiVersion
+# }
+
+query entity($code: String!) {
+  entity(code: $code) {
+    code
+    description
+    type
+    properties {
+      type
+      value
+    }
+    children {
+      code
+      description
+      type
+      properties {
+        type
+        value
+      }
+      children {
+        code
+        description
+        type
+        properties {
+          type
+          value
+        }
+        children {
+          code
+          description
+          type
+          properties {
+            type
+            value
+          }
+          children {
+            code
+            description
+            type
+            properties {
+              type
+              value
+            }
+            children {
+              code
+              description
+              type
+              properties {
+                type
+                value
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/unified-codes/apps/data-loader/src/app/v2/DataLoader.ts
+++ b/unified-codes/apps/data-loader/src/app/v2/DataLoader.ts
@@ -107,6 +107,7 @@ export class DataLoader {
         uid(Entity) <name> "${entity.name}" .
         uid(Entity) <code> "${entity.code}" .
         uid(Entity) <dgraph.type> "${entity.type}" .
+        uid(Entity) <dgraph.type> "Entity" .
       `;
 
       if (await this.dgraph.upsert(query, nQuads)) {

--- a/unified-codes/apps/data-service/src/app/main.ts
+++ b/unified-codes/apps/data-service/src/app/main.ts
@@ -7,6 +7,7 @@ import { EntityResolver } from './v1/resolvers';
 import { DgraphDataSource, RxNavDataSource } from './v1/types';
 
 import { createApolloServer, createFastifyServer, FastifyConfig } from './server';
+import { DgraphGqlDataSource } from './v1/types/DgraphGqlDataSource';
 
 const start = async () => {
   let fastifyServer;
@@ -23,12 +24,14 @@ const start = async () => {
 
     const dataSourcesV1 = () => ({
       dgraph: new DgraphDataSource(),
+      dgraphGql: new DgraphGqlDataSource(),
       rxnav: new RxNavDataSource(),
     });
 
     // TODO: add v2 data sources.
     const dataSourcesV2 = () => ({
       dgraph: new DgraphDataSource(),
+      dgraphGql: new DgraphGqlDataSource(),
       rxnav: new RxNavDataSource(),
     });
 

--- a/unified-codes/apps/data-service/src/app/v1/resolvers.ts
+++ b/unified-codes/apps/data-service/src/app/v1/resolvers.ts
@@ -26,6 +26,7 @@ import {
   EntitySearchInput,
   EntityType,
 } from './schema';
+import { DgraphGqlDataSource } from './types/DgraphGqlDataSource';
 
 @ArgsType()
 class GetEntityArgs {
@@ -80,6 +81,23 @@ export class EntityResolver {
     }
 
     return dgraph.getEntity(code);
+  }
+
+  @Query((returns) => EntityType, { nullable: true })
+  async entity2(@Args() args: GetEntityArgs, @Ctx() ctx: IApolloServiceContext): Promise<IEntity> {
+    const { code } = args;
+    const { token, authenticator, authoriser, dataSources } = ctx;
+
+    const dgraphGql: DgraphGqlDataSource = dataSources.dgraphGql as DgraphGqlDataSource;
+
+    // TODO: add authorisation logic for any protected entities.
+    if (token) {
+      const user: User = await authenticator.authenticate(token);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const isAuthorised = await authoriser.authorise(user);
+    }
+
+    return dgraphGql.getEntity(code);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/unified-codes/apps/data-service/src/app/v1/types/DgraphDataSource.ts
+++ b/unified-codes/apps/data-service/src/app/v1/types/DgraphDataSource.ts
@@ -185,8 +185,12 @@ export class DgraphDataSource extends RESTDataSource {
   }
 
   private static getEntityType(entity: IEntity): string {
-    const { type: types } = entity;
-    const [type] = types ?? [];
+    const { type: dgraphType } = entity;
+    const types = (dgraphType as unknown) as string[]; // dgraph.type is string[]
+
+    // "Entity" is an additional type to allow graphql querying across many entity types
+    // We want the specific type here
+    const type = (types ?? []).find((t) => t !== 'Entity');
 
     switch (type) {
       case EEntityTypeV2.Product:

--- a/unified-codes/apps/data-service/src/app/v1/types/DgraphDataSource.ts
+++ b/unified-codes/apps/data-service/src/app/v1/types/DgraphDataSource.ts
@@ -79,7 +79,7 @@ export class DgraphDataSource extends RESTDataSource {
       query(func: eq(code, ${code?.toLowerCase()}), first:1) @recurse(loop:false) {
         code
         type: dgraph.type
-        description: name@*
+        description: name
         value
         combines
         children
@@ -94,7 +94,7 @@ export class DgraphDataSource extends RESTDataSource {
       query (func: eq(dgraph.type, "Product")) @cascade {
         code
         type: dgraph.type
-        description: name@*
+        description: name
         properties {
           type: dgraph.type
           value
@@ -150,7 +150,7 @@ export class DgraphDataSource extends RESTDataSource {
       return `{
         query(func: eq(dgraph.type, ["Unit", "DoseStrength"]), ${orderString}, offset: ${offset}, first: ${first}) ${filterString}  {
           code
-          description: name@*
+          description: name
           type: dgraph.type
           uid
           properties {
@@ -169,7 +169,7 @@ export class DgraphDataSource extends RESTDataSource {
       
       query(func: uid(all), ${orderString}, offset: ${offset}, first: ${first})  {
         code
-        description: name@*
+        description: name
         type: dgraph.type
         uid
         properties {
@@ -178,7 +178,7 @@ export class DgraphDataSource extends RESTDataSource {
         }
         parents: ~children {
           type: dgraph.type
-          description: name@*
+          description: name
         }
       }
     }`;

--- a/unified-codes/apps/data-service/src/app/v1/types/DgraphGqlDataSource.ts
+++ b/unified-codes/apps/data-service/src/app/v1/types/DgraphGqlDataSource.ts
@@ -1,0 +1,51 @@
+import { RequestOptions, RESTDataSource } from 'apollo-datasource-rest';
+
+import { IEntity } from '@unified-codes/data/v1';
+
+import { getEntityQuery } from './queries/entityQuery';
+
+export class DgraphGqlDataSource extends RESTDataSource {
+  private static headers: { [key: string]: string } = {
+    'Content-Type': 'application/json',
+  };
+
+  constructor() {
+    super();
+    this.baseURL = `${process.env.NX_DGRAPH_SERVICE_URL}:${process.env.NX_DGRAPH_SERVICE_PORT}`;
+  }
+
+  willSendRequest(request: RequestOptions): void {
+    Object.entries(DgraphGqlDataSource.headers).forEach(([key, value]) =>
+      request.headers.set(key, value)
+    );
+  }
+
+  // map empty properties arrays to a null value as it is in the existing schema..
+  private static mapEntity(entity: IEntity) {
+    const children = entity.children?.map((c) => DgraphGqlDataSource.mapEntity(c));
+
+    const properties = entity.properties.length ? entity.properties : null;
+
+    return { ...entity, properties, children };
+  }
+
+  async getEntity(code: string): Promise<IEntity> {
+    const data = await this.postQuery(getEntityQuery(code));
+    const { queryEntity } = data ?? {};
+    const [entity]: [IEntity] = queryEntity ?? [];
+
+    return DgraphGqlDataSource.mapEntity(entity);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async postQuery(query: string): Promise<any> {
+    const response = await this.post(
+      '/graphql',
+      JSON.stringify({
+        query,
+      })
+    );
+    const { data } = response;
+    return data;
+  }
+}

--- a/unified-codes/apps/data-service/src/app/v1/types/queries/entityQuery.ts
+++ b/unified-codes/apps/data-service/src/app/v1/types/queries/entityQuery.ts
@@ -1,6 +1,6 @@
 export const getEntityQuery = (code: string) => `
 {
-  queryEntity(filter: {code: {alloftext: "${code}"}}) {
+  queryEntity(filter: {code: {eq: "${code}"}}) {
     code
     description
     type: __typename

--- a/unified-codes/apps/data-service/src/app/v1/types/queries/entityQuery.ts
+++ b/unified-codes/apps/data-service/src/app/v1/types/queries/entityQuery.ts
@@ -1,52 +1,32 @@
 export const getEntityQuery = (code: string) => `
+fragment Details on Entity {
+  id
+  code
+  type: __typename
+  description
+  properties {
+    type: __typename
+    value
+  }
+}
 {
   queryEntity(filter: {code: {eq: "${code}"}}) {
-    code
-    description
-    type: __typename
-    properties {
-      type: __typename
-      value
-    }
+    ...Details
     children {
-      code
-      description
-      type: __typename
-      properties {
-        type: __typename
-        value
-      }
+      ...Details
       children {
-        code
-        description
-        type: __typename
-        properties {
-          type: __typename
-          value
-        }
-        children {
-          code
-          description
-          type: __typename
-          properties {
-            type: __typename
-            value
-          }
-          children {
-            code
-            description
-            type: __typename
-            properties {
-              type: __typename
-              value
-            }
+        ...Details
+         children {
+          ...Details
+           children {
+            ...Details
             children {
-              code
-              description
-              type: __typename
-              properties {
-                type: __typename
-                value
+              ...Details
+              children {
+                ...Details
+                children {
+                  ...Details
+                }
               }
             }
           }
@@ -55,45 +35,3 @@ export const getEntityQuery = (code: string) => `
     }
   }
 }`;
-
-// TODO: client library so we can use fragments etc...
-// export const getEntityQuery = (code: string) => {
-//   return `
-//   fragment Details on Entity {
-//     id
-//     code
-//     type: __typename
-//     description
-//     properties {
-//       type: __typename
-//       value
-//     }
-//   }
-
-//   query Entity {
-//     queryEntity(filter: {code: {alloftext: "${code}"}}) {
-//       ...Details
-//       children {
-//         ...Details
-//         children {
-//           ...Details
-// 					 children {
-//             ...Details
-// 						 children {
-// 							...Details
-// 							children {
-// 								...Details
-// 								children {
-// 								  ...Details
-// 									children {
-// 						      	...Details
-// 				      		}
-// 								}
-// 							}
-// 						}
-//           }
-//         }
-//       }
-//     }
-//   }`;
-// };

--- a/unified-codes/apps/data-service/src/app/v1/types/queries/entityQuery.ts
+++ b/unified-codes/apps/data-service/src/app/v1/types/queries/entityQuery.ts
@@ -1,0 +1,99 @@
+export const getEntityQuery = (code: string) => `
+{
+  queryEntity(filter: {code: {alloftext: "${code}"}}) {
+    code
+    description
+    type: __typename
+    properties {
+      type: __typename
+      value
+    }
+    children {
+      code
+      description
+      type: __typename
+      properties {
+        type: __typename
+        value
+      }
+      children {
+        code
+        description
+        type: __typename
+        properties {
+          type: __typename
+          value
+        }
+        children {
+          code
+          description
+          type: __typename
+          properties {
+            type: __typename
+            value
+          }
+          children {
+            code
+            description
+            type: __typename
+            properties {
+              type: __typename
+              value
+            }
+            children {
+              code
+              description
+              type: __typename
+              properties {
+                type: __typename
+                value
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+// TODO: client library so we can use fragments etc...
+// export const getEntityQuery = (code: string) => {
+//   return `
+//   fragment Details on Entity {
+//     id
+//     code
+//     type: __typename
+//     description
+//     properties {
+//       type: __typename
+//       value
+//     }
+//   }
+
+//   query Entity {
+//     queryEntity(filter: {code: {alloftext: "${code}"}}) {
+//       ...Details
+//       children {
+//         ...Details
+//         children {
+//           ...Details
+// 					 children {
+//             ...Details
+// 						 children {
+// 							...Details
+// 							children {
+// 								...Details
+// 								children {
+// 								  ...Details
+// 									children {
+// 						      	...Details
+// 				      		}
+// 								}
+// 							}
+// 						}
+//           }
+//         }
+//       }
+//     }
+//   }`;
+// };

--- a/unified-codes/data/v2/schema.gql
+++ b/unified-codes/data/v2/schema.gql
@@ -75,7 +75,7 @@ type PackOuter {
 }
 
 code: string @index(exact, fulltext).
-name: string @lang @index(exact, term, trigram) .
+name: string @index(exact, term, trigram) .
 type: string @index(term) .
 value: string .
 combines: [uid] .

--- a/unified-codes/data/v2/schema.graphql
+++ b/unified-codes/data/v2/schema.graphql
@@ -7,8 +7,8 @@ interface Entity {
   code: String @dgraph(pred: "code") @search(by: [exact, fulltext])
   description: String @dgraph(pred: "name") @search(by: [exact, term, trigram])
   properties: [Property] @dgraph(pred: "properties")
-  children: [Entity] @hasInverse(field: parent) @dgraph(pred: "children")
-  parent: Entity
+  children: [Entity] @dgraph(pred: "children")
+  parents: [Entity] @dgraph(pred: "~children")
 }
 
 type Category implements Entity

--- a/unified-codes/data/v2/schema.graphql
+++ b/unified-codes/data/v2/schema.graphql
@@ -1,0 +1,35 @@
+# THIS IS THE SCHEMA FOR THE DGRAPH GRAPHQL ENDPOINT
+# IT MAPS TO AND THEREFORE CHANGES THE DGRAPH SCHEMA WHEN YOU UPDATE IT
+# WE SHOULD MIGRATE TO ONLY MAINTAINING THIS SCHEMA, AND NOT THE DGRAPH SCHEMA IN ./schema.gql
+
+interface Entity {
+  id: ID!
+  code: String @dgraph(pred: "code") @search(by: [exact, fulltext])
+  description: String @dgraph(pred: "name") @search(by: [exact, term, trigram])
+  properties: [Property] @dgraph(pred: "properties")
+  children: [Entity] @hasInverse(field: parent) @dgraph(pred: "children")
+  parent: Entity
+}
+
+type Category implements Entity
+type Route implements Entity
+type Form implements Entity # DoseForm
+type FormQualifier implements Entity # DoseFormQualifier
+type DoseStrength implements Entity
+type Unit implements Entity #DoseUnit
+type PackImmediate implements Entity
+type PackSize implements Entity
+
+type Product implements Entity {
+  combines: [Product] @dgraph(pred: "combines")
+}
+
+interface Property {
+  id: ID!
+  value: String @dgraph(pred: "value")
+}
+
+type who_eml implements Property
+type code_nzulm implements Property
+type code_rxnav implements Property
+type code_unspsc implements Property

--- a/unified-codes/package.json
+++ b/unified-codes/package.json
@@ -27,6 +27,7 @@
     "update": "nx migrate latest",
     "workspace-schematic": "nx workspace-schematic",
     "dep-graph": "nx dep-graph",
+    "update-dgraph-schema": "curl -X POST localhost:8080/admin/schema --data-binary @data/v2/schema.graphql",
     "help": "nx help"
   },
   "private": true,

--- a/unified-codes/tools/scripts/dgraph/run.sh
+++ b/unified-codes/tools/scripts/dgraph/run.sh
@@ -2,7 +2,7 @@
 
 echo " * Launching dgraph container..."
 if [ "$OSTYPE" == "msys" ]; then
-    winpty docker run --rm -p 8080:8080 -p 9080:9080 -p 8000:8000 -v ~/dgraph:/dgraph dgraph/standalone:v20.03.0
+    winpty docker run --rm -p 8080:8080 -p 9080:9080 -p 8000:8000 -v ~/dgraph:/dgraph dgraph/standalone:v23.1.0
 else
-    docker run --rm -p 8080:8080 -p 9080:9080 -p 8000:8000 -v ~/dgraph:/dgraph dgraph/standalone:v20.03.0
+    docker run --rm -p 8080:8080 -p 9080:9080 -p 8000:8000 -v ~/dgraph:/dgraph dgraph/standalone:v23.1.0
 fi


### PR DESCRIPTION
## Description
<!--- Briefly describe your changes -->

- Updates local devving DGraph Docker image to v23
- Adds a GraphQL schema for Dgraph. There are a few changes related to moving to the GraphQL schema:
  - While Dgraph queries are flexible enough to query across types, GraphQL queries are constrained to a particular type. However DGraph supports nodes having multiple types. 
    - Updated the DataLoader to assign both a generic `Entity` type, as well as the more fine grained type (`Product`/`Route`/`Form` etc) - this allows us to use GraphQL to query the entities across any level of the hierarchy, or target a specific level
  - Removes the `@lang` directive from the `name` predicate - this isn't currently supported through the GraphQL schema (you're supposed to map to language specific fields e.g. `name_en`), but we aren't storing any translations anyway
- Adds npm script to upload the GraphQL schema to Dgraph (this step should probably move into code at some point)
- Adds a new `DgraphGqlDatasource` to the Apollo Server
  - This currently extends a `RESTDataSource`, as it was the quickest way to do a `this.post` of the GraphQL query... next step to replace this with a GraphQL client library, so we get some type support around the queries
- Adds new `entity2` resolver, which resolves an entity as the `entity` resolver does, but using the new `DgraphGqlDatasource`
  - Actually it's slightly less complete than the `entity` resolver - it's currently only returning the data used on the Details page of the existing UC app - to be fleshed out in future PR once we're happy with the pattern
  - There is a `mapEntity` method, as if there are no `properties`, GraphQL returns an empty `properties` array but the existing Dgraph queries return null for some reason (presumably the same for any other array type field)
    - Assuming we need to support the existing API schema, not sure if we just keep to that, doing these mappings, or also create a `v3` that fits more naturally with the GraphQL results?
- To the Admin page of the new frontend (`frontend/packages/host/src/Admin/Settings.tsx`), queries for `entity2` to get a drug and its children/properties (same as in the Details page of the existing Universal Codes app)  - just hardcoded the query for Abacavir :)

## Test

Given that providing a GraphQL schema to Dgraph changes the underlying Dgraph schema, it would be good to double check from a fresh machine that the existing queries are still working as expected (I had many periods along the way where they started returning null, but I think they're ok now 😅)
- Go through [setup instructions](https://github.com/msupply-foundation/unified-codes)
- Test queries (or at least the web app...)
- Upload the GraphQL schema using `npm run update-dgraph-schema`
- Test again

