### PR TITLE
Fix error when querying non-existent entity

### DIFF
--- a/unified-codes/apps/data-service/src/app/v1/types/DgraphDataSource.ts
+++ b/unified-codes/apps/data-service/src/app/v1/types/DgraphDataSource.ts
@@ -78,6 +78,7 @@ export class DgraphDataSource extends RESTDataSource {
     return `{
       query(func: eq(code, ${code?.toLowerCase()}), first:1) @recurse(loop:false) {
         code
+        uid
         type: dgraph.type
         description: name
         value
@@ -93,6 +94,7 @@ export class DgraphDataSource extends RESTDataSource {
     return `{
       query (func: eq(dgraph.type, "Product")) @cascade {
         code
+        uid
         type: dgraph.type
         description: name
         properties {
@@ -186,7 +188,7 @@ export class DgraphDataSource extends RESTDataSource {
 
   private static getEntityType(entity: IEntity): string {
     const { type: dgraphType, parents } = entity;
-    const types = (dgraphType as unknown) as string[]; // dgraph.type is string[]
+    const types = dgraphType as unknown as string[]; // dgraph.type is string[]
 
     // "Entity" is an additional type to allow graphql querying across many entity types
     // We want the specific type here

--- a/unified-codes/apps/data-service/src/app/v1/types/DgraphGqlDataSource.ts
+++ b/unified-codes/apps/data-service/src/app/v1/types/DgraphGqlDataSource.ts
@@ -22,9 +22,11 @@ export class DgraphGqlDataSource extends RESTDataSource {
 
   // map empty properties arrays to a null value as it is in the existing schema..
   private static mapEntity(entity: IEntity) {
+    if (!entity) return entity;
+
     const children = entity.children?.map((c) => DgraphGqlDataSource.mapEntity(c));
 
-    const properties = entity.properties.length ? entity.properties : null;
+    const properties = entity.properties?.length ? entity.properties : null;
 
     return { ...entity, properties, children };
   }

--- a/unified-codes/apps/data-service/src/app/v1/types/DgraphGqlDataSource.ts
+++ b/unified-codes/apps/data-service/src/app/v1/types/DgraphGqlDataSource.ts
@@ -47,7 +47,13 @@ export class DgraphGqlDataSource extends RESTDataSource {
         query,
       })
     );
-    const { data } = response;
+    const { data, errors } = response;
+
+    if (!data) {
+      console.error('Error querying DGraph: ', JSON.stringify(errors));
+      throw new Error('Could not query data');
+    }
+
     return data;
   }
 }


### PR DESCRIPTION
## Description
<!--- Briefly describe your changes -->

If query for entity has no result for whatever reason, we weren't checking for its existence before pulling children off it...

![Screenshot 2023-12-07 at 11 46 08 AM](https://github.com/msupply-foundation/unified-codes/assets/55115239/2c15a367-03d9-4652-8176-78e15e84d112)

Adds a check and early return if `!entity` :)