### PR TITLE
Expose universal codes v1 under the main graphql endpoint

### DIFF
--- a/backend/graphql/Cargo.toml
+++ b/backend/graphql/Cargo.toml
@@ -15,6 +15,7 @@ graphql_core = { path = "core" }
 graphql_types = { path = "types" }
 graphql_general = { path = "general" }
 graphql_user_account = { path = "user_account" }
+graphql_universal_codes = { path = "../graphql_v1/universal_codes" }
 
 
 actix-web = { version = "4.0.1", default-features = false, features = [

--- a/backend/graphql/lib.rs
+++ b/backend/graphql/lib.rs
@@ -10,6 +10,7 @@ use async_graphql_actix_web::{GraphQLRequest, GraphQLResponse};
 use graphql_core::loader::LoaderRegistry;
 use graphql_core::{refresh_token_from_cookie, RefreshTokenData, SelfRequest};
 use graphql_general::GeneralQueries;
+use graphql_universal_codes::UniversalCodesQueries;
 use graphql_user_account::{UserAccountMutations, UserAccountQueries};
 
 use logger::{RequestLogger, ResponseLogger};
@@ -20,7 +21,11 @@ use service::settings::Settings;
 use tokio::sync::mpsc::Sender;
 
 #[derive(MergedObject, Default, Clone)]
-pub struct FullQuery(pub GeneralQueries, pub UserAccountQueries);
+pub struct FullQuery(
+    pub GeneralQueries,
+    pub UserAccountQueries,
+    pub UniversalCodesQueries,
+);
 
 #[derive(MergedObject, Default, Clone)]
 pub struct FullMutation(pub UserAccountMutations);
@@ -29,7 +34,7 @@ pub type Schema = async_graphql::Schema<FullQuery, FullMutation, async_graphql::
 type Builder = SchemaBuilder<FullQuery, FullMutation, EmptySubscription>;
 
 pub fn full_query() -> FullQuery {
-    FullQuery(GeneralQueries, UserAccountQueries)
+    FullQuery(GeneralQueries, UserAccountQueries, UniversalCodesQueries)
 }
 
 pub fn full_mutation() -> FullMutation {

--- a/backend/graphql_v1/universal_codes/src/types/drug_interaction.rs
+++ b/backend/graphql_v1/universal_codes/src/types/drug_interaction.rs
@@ -1,15 +1,3 @@
-/*
-type DrugInteractionType {
-  description: String!
-  name: String!
-  rxcui: String!
-  severity: String!
-  source: String!
-}
-*/
-
-//TODO: Implement this properly, right now this is just stub
-
 use async_graphql::*;
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #459 

## Description
Universal Codes `entities` and `entity` endpoint are now available under the `/graphql` path
