### PR TITLE
468 refactor dgraph to remove extra types

### DIFF
--- a/backend/dgraph/src/entity.rs
+++ b/backend/dgraph/src/entity.rs
@@ -21,7 +21,7 @@ pub async fn entity_by_code(
   __typename
   properties {
     __typename
-    type: __typename
+    type
     value
   }
 }

--- a/backend/dgraph/src/lib.rs
+++ b/backend/dgraph/src/lib.rs
@@ -8,6 +8,7 @@ pub mod entities;
 pub use entities::*;
 pub mod client;
 pub use client::*;
+pub use gql_client::GraphQLError;
 
 // Types to represent the dgraph graphql data
 #[allow(non_snake_case)]
@@ -36,7 +37,7 @@ pub struct Entity {
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Properties {
-    #[serde(rename = "__typename")]
+    #[serde(rename = "type")]
     pub key: String,
     pub value: String,
 }

--- a/data-loader/data/v2/schema.graphql
+++ b/data-loader/data/v2/schema.graphql
@@ -2,7 +2,7 @@
 # IT MAPS TO AND THEREFORE CHANGES THE DGRAPH SCHEMA WHEN YOU UPDATE IT
 # WE SHOULD MIGRATE TO ONLY MAINTAINING THIS SCHEMA, AND NOT THE DGRAPH SCHEMA IN ./schema.gql
 
-interface Entity {
+type Entity {
   id: ID!
   code: String @dgraph(pred: "code") @search(by: [exact, trigram])
   name: String @dgraph(pred: "name") @search(by: [exact, term, trigram])
@@ -14,19 +14,6 @@ interface Entity {
   properties: [Property] @dgraph(pred: "properties")
   children: [Entity] @dgraph(pred: "children")
   parents: [Entity] @dgraph(pred: "~children")
-}
-
-type Category implements Entity
-type Route implements Entity
-type Form implements Entity # DoseForm
-type FormQualifier implements Entity # DoseFormQualifier
-type DoseStrength implements Entity
-type Unit implements Entity #DoseUnit
-type PackImmediate implements Entity
-type PackSize implements Entity
-
-type Product implements Entity {
-  combines: [Product] @dgraph(pred: "combines")
 }
 
 interface Property {

--- a/data-loader/data/v2/schema.graphql
+++ b/data-loader/data/v2/schema.graphql
@@ -16,12 +16,8 @@ type Entity {
   parents: [Entity] @dgraph(pred: "~children")
 }
 
-interface Property {
+type Property {
   id: ID!
+  type: String @dgraph(pred: "type") @search(by: [exact])
   value: String @dgraph(pred: "value")
 }
-
-type who_eml implements Property
-type code_nzulm implements Property
-type code_rxnav implements Property
-type code_unspsc implements Property

--- a/data-loader/src/v2/DataLoader.ts
+++ b/data-loader/src/v2/DataLoader.ts
@@ -153,8 +153,7 @@ export class DataLoader {
 
           const nQuads = `
             _:property <value> "${property.value}" .
-            _:property <dgraph.type> "${property.type}" .
-
+            _:property <type> "${property.type}" .
             uid(Entity) <properties> _:property .
           `;
 

--- a/data-loader/src/v2/DataLoader.ts
+++ b/data-loader/src/v2/DataLoader.ts
@@ -99,7 +99,7 @@ export class DataLoader {
     for await (const entity of entities) {
       const query = `
         query {
-          Entity as var(func: eq(dgraph.type, ${entity.type})) @filter(eq(code, ${entity.code}))
+          Entity as var(func: eq(dgraph.type, "Entity")) @filter(eq(code, ${entity.code}))
         }
       `;
 
@@ -109,7 +109,6 @@ export class DataLoader {
         uid(Entity) <category> "${entity.category}" .
         uid(Entity) <type> "${entity.type}" .
         uid(Entity) <code> "${entity.code}" .
-        uid(Entity) <dgraph.type> "${entity.type}" .
         uid(Entity) <dgraph.type> "Entity" .
       `;
 
@@ -149,7 +148,7 @@ export class DataLoader {
       if (entity.properties) {
         for await (const property of entity.properties) {
           const query = `query {
-            Entity as var(func: eq(dgraph.type, ${entity.type})) @filter(eq(code, ${entity.code}))
+            Entity as var(func: eq(dgraph.type, "Entity")) @filter(eq(code, ${entity.code}))
           }`;
 
           const nQuads = `


### PR DESCRIPTION
Fixes #468 

## Description
All nodes in the Universal Codes DB are now either `Entity` or `Property` types.
Updated queries in rust to maintain compatiblity, dataservice may well be broken now, haven't checked..

### Tests:

- [ ] Integration tests still pass
