### PR TITLE
477 fix links and redirects

### DIFF
--- a/frontend/host/src/Site.tsx
+++ b/frontend/host/src/Site.tsx
@@ -15,6 +15,7 @@ import {
   Navigate,
   Paper,
   useAuthContext,
+  PropsWithChildrenOnly,
 } from '@uc-frontend/common';
 import { AppBar, AppDrawer, Footer, NotFound } from './components';
 import { CommandK } from './CommandK';
@@ -42,63 +43,44 @@ export const Site: FC = () => {
         <Box flex={1} display="flex" flexDirection="column" overflow="hidden">
           <AppBar />
           <Box display="flex" flex={1} overflow="auto" paddingX={'24px'}>
-            <Paper
-              sx={{
-                backgroundColor: 'background.menu',
-                borderRadius: '16px',
-                flex: 1,
-                margin: '10px auto',
-                maxWidth: '1200px',
-                padding: '16px',
-                width: '100%',
-              }}
-            >
-              <Box
-                sx={{
-                  backgroundColor: 'white',
-                  display: 'flex',
-                  borderRadius: '16px',
-                  paddingX: '16px',
-                  height: '100%',
-                  overflow: 'auto',
-                }}
-              >
-                <Routes>
-                  <Route
-                    path={RouteBuilder.create(AppRoute.Browse)
-                      .addWildCard()
-                      .build()}
-                    element={<EntitiesRouter />}
+            <Routes>
+              <Route
+                path={RouteBuilder.create(AppRoute.Browse)
+                  .addWildCard()
+                  .build()}
+                element={
+                  <PageContainer>
+                    <EntitiesRouter />
+                  </PageContainer>
+                }
+              />
+              <Route
+                path={RouteBuilder.create(AppRoute.Admin).addWildCard().build()}
+                element={
+                  <PageContainer>
+                    <RequireAuthentication>
+                      <AdminRouter />
+                    </RequireAuthentication>
+                  </PageContainer>
+                }
+              />
+              <Route
+                path={RouteBuilder.create(AppRoute.Settings)
+                  .addWildCard()
+                  .build()}
+                element={<Settings />}
+              />
+              <Route
+                path={RouteBuilder.create(AppRoute.Home).build()}
+                element={
+                  <Navigate
+                    to={RouteBuilder.create(AppRoute.Browse).build()}
+                    replace={true}
                   />
-                  <Route
-                    path={RouteBuilder.create(AppRoute.Admin)
-                      .addWildCard()
-                      .build()}
-                    element={
-                      <RequireAuthentication>
-                        <AdminRouter />
-                      </RequireAuthentication>
-                    }
-                  />
-                  <Route
-                    path={RouteBuilder.create(AppRoute.Settings)
-                      .addWildCard()
-                      .build()}
-                    element={<Settings />}
-                  />
-                  <Route
-                    path={RouteBuilder.create(AppRoute.Home).build()}
-                    element={
-                      <Navigate
-                        to={RouteBuilder.create(AppRoute.Browse).build()}
-                        replace={true}
-                      />
-                    }
-                  />
-                  <Route path="*" element={<NotFound />} />
-                </Routes>
-              </Box>
-            </Paper>
+                }
+              />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
           </Box>
           <AppFooter />
           <AppFooterPortal SessionDetails={<Footer />} />
@@ -107,5 +89,34 @@ export const Site: FC = () => {
         <QueryErrorHandler />
       </SnackbarProvider>
     </CommandK>
+  );
+};
+
+const PageContainer = ({ children }: PropsWithChildrenOnly) => {
+  return (
+    <Paper
+      sx={{
+        backgroundColor: 'background.menu',
+        borderRadius: '16px',
+        flex: 1,
+        margin: '10px auto',
+        maxWidth: '1200px',
+        padding: '16px',
+        width: '100%',
+      }}
+    >
+      <Box
+        sx={{
+          backgroundColor: 'white',
+          display: 'flex',
+          borderRadius: '16px',
+          paddingX: '16px',
+          height: '100%',
+          overflow: 'auto',
+        }}
+      >
+        {children}
+      </Box>
+    </Paper>
   );
 };

--- a/frontend/system/src/Admin/Service.tsx
+++ b/frontend/system/src/Admin/Service.tsx
@@ -1,24 +1,26 @@
 import React from 'react';
-import { Routes, Route } from '@uc-frontend/common';
+import { Routes, Route, Navigate } from '@uc-frontend/common';
 import { DrugEditForm } from './DrugEditForm';
 import { AppRoute } from 'frontend/config/src';
 import { UserAccountListView } from './Users/ListView';
 import { ConfigurationTabsView } from './Configuration';
 
-const AdminService = () => {
-  return (
-    <Routes>
-      <Route path={`/${AppRoute.NewDrug}`} element={<DrugEditForm />} />
-      <Route
-        path={`/${AppRoute.UserAccounts}`}
-        element={<UserAccountListView />}
-      />
-      <Route
-        path={`/${AppRoute.Configuration}`}
-        element={<ConfigurationTabsView />}
-      />
-    </Routes>
-  );
-};
+const AdminService = () => (
+  <Routes>
+    <Route path={`/${AppRoute.NewDrug}`} element={<DrugEditForm />} />
+    <Route
+      path={`/${AppRoute.UserAccounts}`}
+      element={<UserAccountListView />}
+    />
+    <Route
+      path={`/${AppRoute.Configuration}`}
+      element={<ConfigurationTabsView />}
+    />
+    <Route
+      path="*"
+      element={<Navigate to={`/${AppRoute.Browse}`} replace={true} />}
+    />
+  </Routes>
+);
 
 export default AdminService;


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #477

## Description
<!--- Briefly describe your changes -->

Redirects users away from `/admin/{something-unknown}` paths back to `/browse`, rather than showing the 404 page. This is due to the fact that the breadcrumbs are clickable, but don't actually direct the user to an existent page. Clicking a link within the app and getting taken to a 404 always has the feel of something being broken, so this seemed like the easiest next best thing.

Also moves the Paper/Box wrapper so the 404 page doesn't render within it - that looked weird... this is the before:

<img width="1672" alt="Screenshot 2023-12-22 at 3 57 39 PM" src="https://github.com/msupply-foundation/unified-codes/assets/55115239/e02f6f9b-eaeb-441a-b999-689406852da6">
