### PR TITLE
487 audit logging for new or update codes

### DIFF
--- a/backend/graphql/universal_codes/src/mutations/upsert.rs
+++ b/backend/graphql/universal_codes/src/mutations/upsert.rs
@@ -28,7 +28,11 @@ pub async fn upsert_entity(
     match service_context
         .service_provider
         .universal_codes_service
-        .upsert_entity(input.into())
+        .upsert_entity(
+            ctx.service_provider(),
+            service_context.user_id.clone(),
+            input.into(),
+        )
         .await
     {
         Ok(entity) => Ok(UpsertEntityResponse::Response(EntityType::from_domain(

--- a/backend/service/src/universal_codes/mod.rs
+++ b/backend/service/src/universal_codes/mod.rs
@@ -1,8 +1,11 @@
-use std::fmt::{Display, Formatter};
+use std::{
+    fmt::{Display, Formatter},
+    sync::Arc,
+};
 
 use dgraph::{DgraphClient, Entity, SearchVars};
 
-use crate::{service_provider::ServiceContext, settings::Settings};
+use crate::{service_provider::ServiceProvider, settings::Settings};
 
 pub use self::{entity_collection::EntityCollection, entity_filter::EntitySearchFilter};
 use self::{
@@ -99,9 +102,10 @@ impl UniversalCodesService {
 
     pub async fn upsert_entity(
         &self,
-        // ctx: &ServiceContext,
+        sp: Arc<ServiceProvider>,
+        user_id: String,
         entity: upsert::UpsertUniversalCode,
     ) -> Result<Entity, ModifyUniversalCodeError> {
-        upsert::upsert_entity(self.client.clone(), entity).await
+        upsert::upsert_entity(sp, user_id, self.client.clone(), entity).await
     }
 }

--- a/backend/service/src/universal_codes/tests/upsert.rs
+++ b/backend/service/src/universal_codes/tests/upsert.rs
@@ -20,7 +20,7 @@ mod universal_codes_upsert_test {
             connection_manager,
             get_test_settings(""),
         ));
-        let context = ServiceContext::as_server_admin(service_provider).unwrap();
+        let context = ServiceContext::as_server_admin(service_provider.clone()).unwrap();
         let service = &context.service_provider.universal_codes_service;
 
         let new_code_id = uuid();
@@ -35,7 +35,10 @@ mod universal_codes_upsert_test {
             children: None,
         };
 
-        let result = service.upsert_entity(input).await.unwrap();
+        let result = service
+            .upsert_entity(service_provider.clone(), context.user_id.clone(), input)
+            .await
+            .unwrap();
 
         // TODO: Check it saved correctly
         assert_eq!(result.code, new_code_id);
@@ -53,7 +56,10 @@ mod universal_codes_upsert_test {
             children: None,
         };
 
-        let result = service.upsert_entity(input).await.unwrap();
+        let result = service
+            .upsert_entity(service_provider, context.user_id, input)
+            .await
+            .unwrap();
 
         // TODO: Check it saved correctly
         assert_eq!(result.code, new_code_id);
@@ -74,7 +80,7 @@ mod universal_codes_upsert_test {
             connection_manager,
             get_test_settings(""),
         ));
-        let context = ServiceContext::as_server_admin(service_provider).unwrap();
+        let context = ServiceContext::as_server_admin(service_provider.clone()).unwrap();
         let service = &context.service_provider.universal_codes_service;
 
         let new_code_id = uuid();
@@ -110,7 +116,10 @@ mod universal_codes_upsert_test {
             ]),
         };
 
-        let result = service.upsert_entity(input).await.unwrap();
+        let result = service
+            .upsert_entity(service_provider, context.user_id, input)
+            .await
+            .unwrap();
         assert_eq!(result.children.len(), 2);
     }
 }

--- a/backend/service/src/universal_codes/upsert.rs
+++ b/backend/service/src/universal_codes/upsert.rs
@@ -1,13 +1,15 @@
+use std::sync::Arc;
+
 use crate::{
     audit_log::audit_log_entry,
-    service_provider::{self, ServiceContext},
+    service_provider::{ServiceContext, ServiceProvider},
     universal_codes::code_generator::generate_code,
 };
 use chrono::Utc;
 use dgraph::{
     check_description_duplication, entity_by_code, Entity, EntityInput, GraphQLError, PropertyInput,
 };
-use repository::{LogType, RepositoryError, StorageConnection};
+use repository::{LogType, RepositoryError};
 
 use super::properties::PropertyReference;
 
@@ -47,7 +49,8 @@ pub struct UpsertUniversalCode {
 }
 
 pub async fn upsert_entity(
-    // ctx: &ServiceContext,
+    sp: Arc<ServiceProvider>,
+    user_id: String,
     client: dgraph::DgraphClient,
     updated_entity: UpsertUniversalCode,
 ) -> Result<Entity, ModifyUniversalCodeError> {
@@ -66,7 +69,12 @@ pub async fn upsert_entity(
         for child in children {
             // Using spawn_local partly to avoid errors with async recursion
             // https://docs.rs/async-recursion/latest/async_recursion/ would be another approach, but this also gets us some parallelism
-            let result = tokio::task::spawn_local(upsert_entity(client.clone(), child));
+            let result = tokio::task::spawn_local(upsert_entity(
+                sp.clone(),
+                user_id.clone(),
+                client.clone(),
+                child,
+            ));
             child_handles.push(result);
         }
     }
@@ -89,7 +97,7 @@ pub async fn upsert_entity(
     }
 
     // Validate
-    let _original_entity = validate(&client, &updated_entity).await?;
+    let original_entity = validate(&client, &updated_entity).await?;
 
     // Generate
     let entity_input = generate(updated_entity.clone())?;
@@ -126,24 +134,26 @@ pub async fn upsert_entity(
     };
 
     // Audit logging
-    // match original_entity {
-    //     Some(original_entity) => {
-    //         audit_log_entry(
-    //             &ctx,
-    //             LogType::UniversalCodeUpdated,
-    //             Some(original_entity.code),
-    //             Utc::now().naive_utc(),
-    //         )?;
-    //     }
-    //     None => {
-    //         audit_log_entry(
-    //             &ctx,
-    //             LogType::UniversalCodeCreated,
-    //             Some(updated_entity.code.clone()),
-    //             Utc::now().naive_utc(),
-    //         )?;
-    //     }
-    // }
+
+    let service_context = ServiceContext::with_user(sp.clone(), user_id)?;
+    match original_entity {
+        Some(original_entity) => {
+            audit_log_entry(
+                &service_context,
+                LogType::UniversalCodeUpdated,
+                Some(original_entity.code),
+                Utc::now().naive_utc(),
+            )?;
+        }
+        None => {
+            audit_log_entry(
+                &service_context,
+                LogType::UniversalCodeCreated,
+                Some(updated_entity.code.clone()),
+                Utc::now().naive_utc(),
+            )?;
+        }
+    }
 
     Ok(updated_entity)
 }


### PR DESCRIPTION
Fixes #487 

## Description
Because the dgraph graphql library requires async functions, we weren't able t pass our normal `context` object around (with the storage connection it's not threadsafe)

To avoid this problem, I'm passing the user_id an service provider, then we can create connection in the function which needs to write to the audit log.
The storage connection is to allow functions to inherit database transactions for subsequent function calls.
Since we're not actually creating a transaction here, it's no needed.

Might be nice to create a new context struct though?

