### PR TITLE
495 fix clickable whitespace

### DIFF
--- a/frontend/system/src/Entities/EntityDetails.tsx
+++ b/frontend/system/src/Entities/EntityDetails.tsx
@@ -6,12 +6,13 @@ import {
   ChevronDownIcon,
   EditIcon,
   Switch,
+  Box,
 } from '@common/ui';
 import { useBreadcrumbs } from '@common/hooks';
 import { useEntity } from './api';
 import { FormControlLabel } from '@mui/material';
 import { TreeView } from '@mui/lab';
-import { Link, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { EntityTreeItem, EntityData } from './EntityTreeItem';
 import { RouteBuilder } from '@common/utils';
 import { AppRoute } from 'frontend/config/src';
@@ -22,6 +23,7 @@ export const EntityDetails = () => {
   const t = useTranslation('system');
   const { code } = useParams();
   const { setSuffix } = useBreadcrumbs();
+  const navigate = useNavigate();
   const [expanded, setExpanded] = useState<string[]>([]);
   const [showAllCodes, setShowAllCodes] = useState(false);
   const { hasPermission } = useAuthContext();
@@ -82,21 +84,22 @@ export const EntityDetails = () => {
       </TreeView>
 
       {hasPermission(PermissionNode.ServerAdmin) && (
-        <Link
-          style={{ height: 'fit-content' }}
-          to={RouteBuilder.create(AppRoute.Admin)
-            .addPart(AppRoute.Edit)
-            .addPart(entity?.code ?? '')
-            .build()}
-        >
+        <Box>
           <ButtonWithIcon
             sx={{ marginTop: '16px' }}
             variant="contained"
-            onClick={() => {}}
+            onClick={() => {
+              navigate(
+                RouteBuilder.create(AppRoute.Admin)
+                  .addPart(AppRoute.Edit)
+                  .addPart(entity?.code ?? '')
+                  .build()
+              );
+            }}
             Icon={<EditIcon />}
             label={t('label.update')}
           />
-        </Link>
+        </Box>
       )}
     </>
   );

--- a/frontend/system/src/Entities/EntityDetails.tsx
+++ b/frontend/system/src/Entities/EntityDetails.tsx
@@ -83,6 +83,7 @@ export const EntityDetails = () => {
 
       {hasPermission(PermissionNode.ServerAdmin) && (
         <Link
+          style={{ height: 'fit-content' }}
           to={RouteBuilder.create(AppRoute.Admin)
             .addPart(AppRoute.Edit)
             .addPart(entity?.code ?? '')


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #495

## Description
<!--- Briefly describe your changes -->

Switches from a Link component wrapper to using `navigate` on click. The Link component was taking on a full height, thus the clickable whitespace. We could have fixed this with CSS, but given the navigation is the result of the click, the navigate function seemed like the more appropriate option.

No longer clickable in the whitespace:
<img width="992" alt="Screenshot 2024-01-09 at 4 34 22 PM" src="https://github.com/msupply-foundation/unified-codes/assets/55115239/44e54161-aaaa-4e4c-bb1d-7a92035972e3">

