### PR TITLE
Use helper for dGraph retries

### DIFF
--- a/backend/dgraph/Cargo.toml
+++ b/backend/dgraph/Cargo.toml
@@ -12,6 +12,7 @@ tokio = { version = "1", features = ["full"] }
 gql_client = "1.0.7"
 util = { path = "../util" }
 log = "0.4.14"
+rand = "0.8"
 
 [features]
 dgraph-tests = []

--- a/backend/dgraph/src/client.rs
+++ b/backend/dgraph/src/client.rs
@@ -1,14 +1,67 @@
-use gql_client::Client;
+use rand::prelude::*;
+use std::usize;
+
+use gql_client::{Client, GraphQLError};
+use serde::{Deserialize, Serialize};
+
+// Dgraph sometimes returns an error like this:
+// {"errors":[{"message":"Transaction has been aborted. Please retry","locations":[{"line":2,"column":3}],"extensions":{"code":"Error"}}],"data":null}
+// Seems to mostly happen in tests, but in case this happens in production we'll retry a few times
+// Sounds like this could possibly be to do with updating the same index?
+const DEFAULT_RETRIES: usize = 3;
+const DEFAULT_RETRY_DELAY: u64 = 10;
 
 #[derive(Clone)]
 pub struct DgraphClient {
     pub gql: Client,
+    pub retries: usize,
+    pub retry_delay: u64,
 }
 
 impl DgraphClient {
     pub fn new(url: &str) -> Self {
         DgraphClient {
             gql: Client::new(url),
+            retries: DEFAULT_RETRIES,
+            retry_delay: DEFAULT_RETRY_DELAY,
         }
+    }
+
+    pub async fn query_with_retry<K, T: Serialize + Clone>(
+        &self,
+        query: &str,
+        variables: T,
+    ) -> Result<Option<K>, GraphQLError>
+    where
+        K: for<'de> Deserialize<'de>,
+    {
+        let mut attempts = 0;
+        while attempts < self.retries {
+            let result = self
+                .gql
+                .query_with_vars::<K, T>(&query, variables.clone())
+                .await;
+            match result {
+                Ok(result) => return Ok(result),
+                Err(err) => {
+                    attempts += 1;
+
+                    if attempts >= self.retries {
+                        // Retries are done, time to give up
+                        // Return the actual error if there is one...
+                        return Err(err);
+                    }
+                    log::error!("Query failed, retrying - {:#?} : {:#?}", query, err);
+                    // Delay for a bit before retrying
+                    let delay = rand::thread_rng().gen_range(1..self.retry_delay);
+                    tokio::time::sleep(tokio::time::Duration::from_millis(delay)).await;
+                    continue;
+                }
+            };
+        }
+        Err(GraphQLError::with_text(format!(
+            "Query failed after {} attempts",
+            attempts
+        )))
     }
 }

--- a/backend/dgraph/src/link_codes.rs
+++ b/backend/dgraph/src/link_codes.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::DgraphClient;
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Clone)]
 struct LinkCodesVars {
     parent: String,
     child: String,
@@ -37,8 +37,7 @@ mutation LinkCodes($parent: String!, $child: String!) {
     let variables = LinkCodesVars { parent, child };
 
     let result = client
-        .gql
-        .query_with_vars::<LinkResponseData, LinkCodesVars>(&query, variables)
+        .query_with_retry::<LinkResponseData, LinkCodesVars>(&query, variables)
         .await?;
 
     match result {


### PR DESCRIPTION
Fixes #510 

## Description
Uses a helper function with re-tries to avoid mutation conflicts when doing parallel updates/deletes.

### Tests:
`cargo test --features=dgraph-tests`