### PR TITLE
517 remove requested for

### DIFF
--- a/backend/dgraph/src/lib.rs
+++ b/backend/dgraph/src/lib.rs
@@ -129,8 +129,6 @@ pub struct PendingChange {
     #[serde(default)]
     pub requested_by_user_id: String,
     #[serde(default)]
-    pub requested_for: String,
-    #[serde(default)]
     pub status: ChangeStatus,
     #[serde(default)]
     pub body: String,
@@ -176,7 +174,6 @@ pub struct PendingChangeInput {
     pub change_type: ChangeType,
     pub date_requested: NaiveDateTime,
     pub requested_by_user_id: String,
-    pub requested_for: String,
     pub status: ChangeStatus,
     pub body: String,
 }

--- a/backend/dgraph/src/pending_change.rs
+++ b/backend/dgraph/src/pending_change.rs
@@ -22,7 +22,6 @@ query PendingChangeQuery($request_id: String!) {
     change_type
     date_requested
     requested_by_user_id
-    requested_for
     body
     status
   }

--- a/backend/dgraph/src/pending_changes.rs
+++ b/backend/dgraph/src/pending_changes.rs
@@ -44,7 +44,6 @@ query PendingChangesQuery($filter: PendingChangeFilter, $first: Int, $offset: In
     change_type
     date_requested
     requested_by_user_id
-    requested_for
     body
     status
   }

--- a/backend/graphql/types/src/types/pending_change.rs
+++ b/backend/graphql/types/src/types/pending_change.rs
@@ -38,9 +38,6 @@ impl PendingChangeNode {
     pub async fn date_requested(&self) -> &DateTime<Utc> {
         &self.row().date_requested
     }
-    pub async fn requested_for(&self) -> &str {
-        &self.row().requested_for
-    }
     pub async fn status(&self) -> ChangeStatusNode {
         ChangeStatusNode::from_domain(self.row().status.clone())
     }

--- a/backend/graphql/universal_codes/src/types/inputs.rs
+++ b/backend/graphql/universal_codes/src/types/inputs.rs
@@ -117,7 +117,6 @@ pub struct RequestChangeInput {
     pub category: String,
     pub body: String,
     pub change_type: ChangeTypeNode,
-    pub requested_for: String,
 }
 
 impl From<RequestChangeInput> for AddPendingChange {
@@ -126,7 +125,6 @@ impl From<RequestChangeInput> for AddPendingChange {
             request_id,
             name,
             category,
-            requested_for,
             body,
             change_type,
         }: RequestChangeInput,
@@ -136,7 +134,6 @@ impl From<RequestChangeInput> for AddPendingChange {
             name,
             category,
             body,
-            requested_for,
             change_type: ChangeTypeNode::to_domain(change_type),
         }
     }

--- a/backend/service/src/universal_codes/add_pending_change.rs
+++ b/backend/service/src/universal_codes/add_pending_change.rs
@@ -17,7 +17,6 @@ pub struct AddPendingChange {
     pub category: String,
     pub body: String,
     pub change_type: ChangeType,
-    pub requested_for: String,
 }
 
 pub async fn add_pending_change(
@@ -76,7 +75,6 @@ pub fn generate(
         category: change_request.category.clone(),
         body: change_request.body.clone(),
         change_type: change_request.change_type.clone(),
-        requested_for: change_request.requested_for.clone(),
 
         status: ChangeStatus::Pending,
         date_requested: Utc::now().naive_utc(),
@@ -101,11 +99,6 @@ pub async fn validate(
     if pending_change.body.clone().is_empty() {
         return Err(ModifyUniversalCodeError::InternalError(
             "Body is required".to_string(),
-        ));
-    }
-    if pending_change.requested_for.clone().is_empty() {
-        return Err(ModifyUniversalCodeError::InternalError(
-            "Requested For is required".to_string(),
         ));
     }
 

--- a/backend/service/src/universal_codes/tests/add_pending_change.rs
+++ b/backend/service/src/universal_codes/tests/add_pending_change.rs
@@ -31,7 +31,6 @@ mod universal_codes_add_pending_change_test {
             name: new_request_id.clone(),
             category: "test_category".to_string(),
             body: "test body".to_string(),
-            requested_for: "test country".to_string(),
             change_type: ChangeType::New,
         };
 
@@ -75,7 +74,6 @@ mod universal_codes_add_pending_change_test {
             name: new_request_id.clone(),
             category: "".to_string(),
             body: "test body".to_string(),
-            requested_for: "test country".to_string(),
             change_type: ChangeType::New,
         };
 

--- a/backend/service/src/universal_codes/tests/reject_pending_change.rs
+++ b/backend/service/src/universal_codes/tests/reject_pending_change.rs
@@ -32,7 +32,6 @@ mod universal_codes_reject_pending_change_test {
             name: request_id.clone(),
             category: "test_category".to_string(),
             body: "test body".to_string(),
-            requested_for: "test country".to_string(),
             change_type: ChangeType::New,
         };
 

--- a/backend/service/src/universal_codes/tests/update_pending_change_body.rs
+++ b/backend/service/src/universal_codes/tests/update_pending_change_body.rs
@@ -34,7 +34,6 @@ mod universal_codes_update_pending_change_body_test {
             name: request_id.clone(),
             category: "test_category".to_string(),
             body: "test body".to_string(),
-            requested_for: "test country".to_string(),
             change_type: ChangeType::New,
         };
 
@@ -147,7 +146,6 @@ mod universal_codes_update_pending_change_body_test {
             name: request_id.clone(),
             category: "test_category".to_string(),
             body: "test body".to_string(),
-            requested_for: "test country".to_string(),
             change_type: ChangeType::New,
         };
 

--- a/data-loader/data/v2/schema.graphql
+++ b/data-loader/data/v2/schema.graphql
@@ -45,7 +45,6 @@ type PendingChange {
   change_type: ChangeType!
   date_requested: DateTime!
   requested_by_user_id: String!
-  requested_for: String!
   status: ChangeStatus! @search(by: [exact])
   body: String!
 }

--- a/frontend/common/src/types/schema.ts
+++ b/frontend/common/src/types/schema.ts
@@ -495,7 +495,6 @@ export type PendingChangeNode = {
   name: Scalars['String']['output'];
   requestId: Scalars['String']['output'];
   requestedBy: Scalars['String']['output'];
-  requestedFor: Scalars['String']['output'];
   status: ChangeStatusNode;
 };
 
@@ -558,7 +557,6 @@ export type RequestChangeInput = {
   changeType: ChangeTypeNode;
   name: Scalars['String']['input'];
   requestId: Scalars['String']['input'];
-  requestedFor: Scalars['String']['input'];
 };
 
 export type RequestChangeResponse = PendingChangeNode;

--- a/frontend/system/src/Admin/EditEntity/ConsumableEditForm.tsx
+++ b/frontend/system/src/Admin/EditEntity/ConsumableEditForm.tsx
@@ -59,7 +59,6 @@ export const ConsumableEditForm = ({
         category: EntityCategory.Consumable,
         changeType: initialEntity ? ChangeTypeNode.Change : ChangeTypeNode.New,
         name: draft.name,
-        requestedFor: 'Country - coming soon', // TODO: capture this
         body: JSON.stringify(entity),
         // NOTE: storing the full entity, which will be upserted on approval. If two change requests are
         // made, there will be a conflict, and the second would overwrite the first. However it doesn't seem

--- a/frontend/system/src/Admin/EditEntity/DrugEditForm.tsx
+++ b/frontend/system/src/Admin/EditEntity/DrugEditForm.tsx
@@ -51,7 +51,6 @@ export const DrugEditForm = ({
         category: EntityCategory.Drug,
         changeType: initialEntity ? ChangeTypeNode.Change : ChangeTypeNode.New,
         name: draft.name,
-        requestedFor: 'Country - coming soon', // TODO: capture this
         body: JSON.stringify(entity),
         // NOTE: storing the full entity, which will be upserted on approval. If two change requests are
         // made, there will be a conflict, and the second would overwrite the first. However it doesn't seem

--- a/frontend/system/src/Admin/EditEntity/VaccineEditForm.tsx
+++ b/frontend/system/src/Admin/EditEntity/VaccineEditForm.tsx
@@ -51,7 +51,6 @@ export const VaccineEditForm = ({
         category: EntityCategory.Vaccine,
         changeType: initialEntity ? ChangeTypeNode.Change : ChangeTypeNode.New,
         name: draft.name,
-        requestedFor: 'Country - coming soon', // TODO: capture this - double check this is useful info?
         body: JSON.stringify(entity),
         // NOTE: storing the full entity, which will be upserted on approval. If two change requests are
         // made, there will be a conflict, and the second would overwrite the first. However it doesn't seem

--- a/frontend/system/src/Admin/PendingChanges/ListView.tsx
+++ b/frontend/system/src/Admin/PendingChanges/ListView.tsx
@@ -38,7 +38,6 @@ export const PendingChangesListView = () => {
       },
       { key: 'changeType', label: 'label.change-type', sortable: false },
       { key: 'requestedBy', label: 'label.requested-by', sortable: false },
-      { key: 'requestedFor', label: 'label.request-for', sortable: false },
     ],
     { sortBy: sortBy, onChangeSortBy: updateSortQuery },
     [sortBy, updateSortQuery]

--- a/frontend/system/src/Admin/api/operations.generated.ts
+++ b/frontend/system/src/Admin/api/operations.generated.ts
@@ -18,7 +18,7 @@ export type RejectPendingChangeMutationVariables = Types.Exact<{
 
 export type RejectPendingChangeMutation = { __typename?: 'FullMutation', rejectPendingChange: { __typename?: 'IdResponse', id: string } };
 
-export type PendingChangeSummaryFragment = { __typename?: 'PendingChangeNode', name: string, category: string, changeType: Types.ChangeTypeNode, requestedBy: string, requestedFor: string, dateRequested: string, id: string };
+export type PendingChangeSummaryFragment = { __typename?: 'PendingChangeNode', name: string, category: string, changeType: Types.ChangeTypeNode, requestedBy: string, dateRequested: string, id: string };
 
 export type PendingChangesQueryVariables = Types.Exact<{
   page?: Types.InputMaybe<Types.PaginationInput>;
@@ -26,16 +26,16 @@ export type PendingChangesQueryVariables = Types.Exact<{
 }>;
 
 
-export type PendingChangesQuery = { __typename?: 'FullQuery', pendingChanges: { __typename?: 'PendingChangeConnector', totalCount: number, nodes: Array<{ __typename?: 'PendingChangeNode', name: string, category: string, changeType: Types.ChangeTypeNode, requestedBy: string, requestedFor: string, dateRequested: string, id: string }> } };
+export type PendingChangesQuery = { __typename?: 'FullQuery', pendingChanges: { __typename?: 'PendingChangeConnector', totalCount: number, nodes: Array<{ __typename?: 'PendingChangeNode', name: string, category: string, changeType: Types.ChangeTypeNode, requestedBy: string, dateRequested: string, id: string }> } };
 
-export type PendingChangeDetailsFragment = { __typename?: 'PendingChangeNode', name: string, category: string, changeType: Types.ChangeTypeNode, requestedBy: string, requestedFor: string, dateRequested: string, body: string, id: string };
+export type PendingChangeDetailsFragment = { __typename?: 'PendingChangeNode', name: string, category: string, changeType: Types.ChangeTypeNode, requestedBy: string, dateRequested: string, body: string, id: string };
 
 export type PendingChangeQueryVariables = Types.Exact<{
   id: Types.Scalars['String']['input'];
 }>;
 
 
-export type PendingChangeQuery = { __typename?: 'FullQuery', pendingChange?: { __typename?: 'PendingChangeNode', name: string, category: string, changeType: Types.ChangeTypeNode, requestedBy: string, requestedFor: string, dateRequested: string, body: string, id: string } | null };
+export type PendingChangeQuery = { __typename?: 'FullQuery', pendingChange?: { __typename?: 'PendingChangeNode', name: string, category: string, changeType: Types.ChangeTypeNode, requestedBy: string, dateRequested: string, body: string, id: string } | null };
 
 export type RequestChangeMutationVariables = Types.Exact<{
   input: Types.RequestChangeInput;
@@ -59,7 +59,6 @@ export const PendingChangeSummaryFragmentDoc = gql`
   category
   changeType
   requestedBy
-  requestedFor
   dateRequested
 }
     `;
@@ -70,7 +69,6 @@ export const PendingChangeDetailsFragmentDoc = gql`
   category
   changeType
   requestedBy
-  requestedFor
   dateRequested
   body
 }

--- a/frontend/system/src/Admin/api/operations.graphql
+++ b/frontend/system/src/Admin/api/operations.graphql
@@ -19,7 +19,6 @@ fragment PendingChangeSummary on PendingChangeNode {
   category
   changeType
   requestedBy
-  requestedFor
   dateRequested
 }
 
@@ -40,7 +39,6 @@ fragment PendingChangeDetails on PendingChangeNode {
   category
   changeType
   requestedBy
-  requestedFor
   dateRequested
   body
 }


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #517

## Description
<!--- Briefly describe your changes -->
Removes the `requestedFor` field from pending changes:
<img width="1152" alt="Screenshot 2024-01-22 at 5 20 51 PM" src="https://github.com/msupply-foundation/unified-codes/assets/55115239/9eca853d-a7e6-4113-ba90-b9c27a091cca">

Removes the property entirely, rather than just not displaying... this field was mostly to explain _why_ the change is being requested, which we'll only really need once external submissions are available, but something like a `reason` field will probably make more sense then.
