### PR TITLE
redirect old details route to new page

### DIFF
--- a/frontend/host/src/RedirectDetails.tsx
+++ b/frontend/host/src/RedirectDetails.tsx
@@ -1,0 +1,17 @@
+import { RouteBuilder } from '@common/utils';
+import { AppRoute } from 'frontend/config/src';
+import React from 'react';
+import { Navigate, useParams } from 'react-router-dom';
+
+export const RedirectDetails = () => {
+  const { code } = useParams();
+
+  return (
+    <Navigate
+      to={RouteBuilder.create(AppRoute.Browse)
+        .addPart(code || '')
+        .build()}
+      replace={true}
+    />
+  );
+};

--- a/frontend/host/src/Site.tsx
+++ b/frontend/host/src/Site.tsx
@@ -25,6 +25,7 @@ import { QueryErrorHandler } from './QueryErrorHandler';
 import { EntitiesRouter } from './routers/EntitiesRouter';
 import { AdminRouter } from './routers/AdminRouter';
 import { RequireAuthentication } from './components/Navigation/RequireAuthentication';
+import { RedirectDetails } from './RedirectDetails';
 
 const AboutPage = React.lazy(
   () => import('@uc-frontend/system/src/About/About')
@@ -91,6 +92,7 @@ export const Site: FC = () => {
                   />
                 }
               />
+              <Route path={'/details/:code'} element={<RedirectDetails />} />
               <Route path="*" element={<NotFound />} />
             </Routes>
           </Box>


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #483

## Description
<!--- Briefly describe your changes -->

Redirects `/details/:code` pages to `/browse/:code`, so links from the old web app will get redirected as expected in the new web app!

Test:
- Go to: http://localhost:4201/details/c7750265
- You should be redirected to http://localhost:4201/browse/c7750265 and see the Abacavir details

