### PR TITLE
509 suggest existing code

### DIFF
--- a/frontend/common/src/intl/locales/en/system.json
+++ b/frontend/common/src/intl/locales/en/system.json
@@ -86,6 +86,7 @@
   "property-who_eml": "WHO EML Categories",
   "property-code_unspsc": "UNSPSC Code",
   "message.status-updated": "Change request {{ status }} for {{ name }}",
+  "message.did-you-mean": "Did you mean {{ suggestion }}?",
   "message.entity-created": "Request submitted to create {{ name }}",
   "message.entity-updated": "Request submitted to update {{ name }}",
   "message.entity-error": "Error creating or updating this entity",

--- a/frontend/system/src/Admin/EditEntity/components/ConsumableFormTree.tsx
+++ b/frontend/system/src/Admin/EditEntity/components/ConsumableFormTree.tsx
@@ -9,7 +9,7 @@ import { TreeFormBox } from './TreeFormBox';
 import { AddFieldButton } from './AddFieldButton';
 import { EditPropertiesButton } from './EditPropertiesButton';
 import { NameEditField } from './NameEditField';
-import { ExistingNameSuggestor } from './ExistingItemSuggestor';
+import { ExistingNameSuggester } from './ExistingItemSuggester';
 
 export const ConsumableFormTree = ({
   draft,
@@ -127,7 +127,7 @@ export const ConsumableFormTree = ({
       </Box>
 
       {/* No initial ids === new item */}
-      {!initialIds.length && <ExistingNameSuggestor name={draft.name} />}
+      {!initialIds.length && <ExistingNameSuggester name={draft.name} />}
 
       {!!draft.presentations.length && (
         <Typography fontSize="12px">{t('label.presentations')}</Typography>

--- a/frontend/system/src/Admin/EditEntity/components/ConsumableFormTree.tsx
+++ b/frontend/system/src/Admin/EditEntity/components/ConsumableFormTree.tsx
@@ -9,6 +9,7 @@ import { TreeFormBox } from './TreeFormBox';
 import { AddFieldButton } from './AddFieldButton';
 import { EditPropertiesButton } from './EditPropertiesButton';
 import { NameEditField } from './NameEditField';
+import { ExistingNameSuggestor } from './ExistingItemSuggestor';
 
 export const ConsumableFormTree = ({
   draft,
@@ -124,6 +125,9 @@ export const ConsumableFormTree = ({
           />
         </Box>
       </Box>
+
+      {/* No initial ids === new item */}
+      {!initialIds.length && <ExistingNameSuggestor name={draft.name} />}
 
       {!!draft.presentations.length && (
         <Typography fontSize="12px">{t('label.presentations')}</Typography>

--- a/frontend/system/src/Admin/EditEntity/components/DrugFormTree.tsx
+++ b/frontend/system/src/Admin/EditEntity/components/DrugFormTree.tsx
@@ -13,6 +13,9 @@ import { NameEditField } from './NameEditField';
 import { useConfigurationItems } from '../../Configuration/api';
 import { ConfigurationItemTypeInput } from '@common/types';
 import { useEntities } from 'frontend/system/src/Entities/api';
+import { Link } from 'react-router-dom';
+import { RouteBuilder } from '@common/utils';
+import { AppRoute } from 'frontend/config/src';
 
 export const DrugFormTree = ({
   draft,
@@ -147,10 +150,17 @@ export const DrugFormTree = ({
           />
         </Box>
       </Box>
+      {/* TODO: only display me on new form! */}
       {match && (
-        <Typography>
+        <Link
+          style={{ display: 'block', marginLeft: '10px' }}
+          to={RouteBuilder.create(AppRoute.Admin)
+            .addPart(AppRoute.Edit)
+            .addPart(match.code)
+            .build()}
+        >
           Did you mean {match.description} ({match.code})?
-        </Typography>
+        </Link>
       )}
 
       {!!draft.routes.length && (

--- a/frontend/system/src/Admin/EditEntity/components/DrugFormTree.tsx
+++ b/frontend/system/src/Admin/EditEntity/components/DrugFormTree.tsx
@@ -136,6 +136,7 @@ export const DrugFormTree = ({
           />
         </Box>
       </Box>
+
       {/* No initial ids === new item */}
       {!initialIds.length && <ExistingNameSuggestor name={draft.name} />}
 

--- a/frontend/system/src/Admin/EditEntity/components/DrugFormTree.tsx
+++ b/frontend/system/src/Admin/EditEntity/components/DrugFormTree.tsx
@@ -150,8 +150,8 @@ export const DrugFormTree = ({
           />
         </Box>
       </Box>
-      {/* TODO: only display me on new form! */}
-      {match && (
+      {/* No initial ids === new item */}
+      {!initialIds.length && match && (
         <Link
           style={{ display: 'block', marginLeft: '10px' }}
           to={RouteBuilder.create(AppRoute.Admin)

--- a/frontend/system/src/Admin/EditEntity/components/DrugFormTree.tsx
+++ b/frontend/system/src/Admin/EditEntity/components/DrugFormTree.tsx
@@ -12,7 +12,7 @@ import { EditPropertiesButton } from './EditPropertiesButton';
 import { NameEditField } from './NameEditField';
 import { useConfigurationItems } from '../../Configuration/api';
 import { ConfigurationItemTypeInput } from '@common/types';
-import { ExistingNameSuggestor } from './ExistingItemSuggestor';
+import { ExistingNameSuggester } from './ExistingItemSuggester';
 
 export const DrugFormTree = ({
   draft,
@@ -138,7 +138,7 @@ export const DrugFormTree = ({
       </Box>
 
       {/* No initial ids === new item */}
-      {!initialIds.length && <ExistingNameSuggestor name={draft.name} />}
+      {!initialIds.length && <ExistingNameSuggester name={draft.name} />}
 
       {!!draft.routes.length && (
         <Typography fontSize="12px">{t('label.routes')}</Typography>

--- a/frontend/system/src/Admin/EditEntity/components/DrugFormTree.tsx
+++ b/frontend/system/src/Admin/EditEntity/components/DrugFormTree.tsx
@@ -12,10 +12,7 @@ import { EditPropertiesButton } from './EditPropertiesButton';
 import { NameEditField } from './NameEditField';
 import { useConfigurationItems } from '../../Configuration/api';
 import { ConfigurationItemTypeInput } from '@common/types';
-import { useEntities } from 'frontend/system/src/Entities/api';
-import { Link } from 'react-router-dom';
-import { RouteBuilder } from '@common/utils';
-import { AppRoute } from 'frontend/config/src';
+import { ExistingNameSuggestor } from './ExistingItemSuggestor';
 
 export const DrugFormTree = ({
   draft,
@@ -44,17 +41,6 @@ export const DrugFormTree = ({
     onOpen,
     entity: propertiesModalData,
   } = useEditModal<Property[]>();
-
-  const { data: matchingEntities } = useEntities({
-    filter: {
-      categories: ['drug', 'consumable', 'vaccine'],
-      match: 'exact',
-      description: draft.name,
-    },
-    first: 1,
-    offset: 0,
-  });
-  const match = matchingEntities?.data[0];
 
   // Get the route, form, and immediate packaging options
   const { data: routes, isLoading: isLoadingRoutes } = useConfigurationItems({
@@ -151,19 +137,7 @@ export const DrugFormTree = ({
         </Box>
       </Box>
       {/* No initial ids === new item */}
-      {!initialIds.length && match && (
-        <Link
-          style={{ display: 'block', marginLeft: '10px' }}
-          to={RouteBuilder.create(AppRoute.Admin)
-            .addPart(AppRoute.Edit)
-            .addPart(match.code)
-            .build()}
-        >
-          {t('message.did-you-mean', {
-            suggestion: `${match.description} (${match.code})`,
-          })}
-        </Link>
-      )}
+      {!initialIds.length && <ExistingNameSuggestor name={draft.name} />}
 
       {!!draft.routes.length && (
         <Typography fontSize="12px">{t('label.routes')}</Typography>

--- a/frontend/system/src/Admin/EditEntity/components/DrugFormTree.tsx
+++ b/frontend/system/src/Admin/EditEntity/components/DrugFormTree.tsx
@@ -12,6 +12,7 @@ import { EditPropertiesButton } from './EditPropertiesButton';
 import { NameEditField } from './NameEditField';
 import { useConfigurationItems } from '../../Configuration/api';
 import { ConfigurationItemTypeInput } from '@common/types';
+import { useEntities } from 'frontend/system/src/Entities/api';
 
 export const DrugFormTree = ({
   draft,
@@ -40,6 +41,17 @@ export const DrugFormTree = ({
     onOpen,
     entity: propertiesModalData,
   } = useEditModal<Property[]>();
+
+  const { data: matchingEntities } = useEntities({
+    filter: {
+      categories: ['drug', 'consumable', 'vaccine'],
+      match: 'exact',
+      description: draft.name,
+    },
+    first: 1,
+    offset: 0,
+  });
+  const match = matchingEntities?.data[0];
 
   // Get the route, form, and immediate packaging options
   const { data: routes, isLoading: isLoadingRoutes } = useConfigurationItems({
@@ -135,6 +147,11 @@ export const DrugFormTree = ({
           />
         </Box>
       </Box>
+      {match && (
+        <Typography>
+          Did you mean {match.description} ({match.code})?
+        </Typography>
+      )}
 
       {!!draft.routes.length && (
         <Typography fontSize="12px">{t('label.routes')}</Typography>

--- a/frontend/system/src/Admin/EditEntity/components/DrugFormTree.tsx
+++ b/frontend/system/src/Admin/EditEntity/components/DrugFormTree.tsx
@@ -159,7 +159,9 @@ export const DrugFormTree = ({
             .addPart(match.code)
             .build()}
         >
-          Did you mean {match.description} ({match.code})?
+          {t('message.did-you-mean', {
+            suggestion: `${match.description} (${match.code})`,
+          })}
         </Link>
       )}
 

--- a/frontend/system/src/Admin/EditEntity/components/ExistingItemSuggester.tsx
+++ b/frontend/system/src/Admin/EditEntity/components/ExistingItemSuggester.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import { RouteBuilder } from '@common/utils';
 import { AppRoute } from 'frontend/config/src';
 
-export const ExistingNameSuggestor = ({ name }: { name: string }) => {
+export const ExistingNameSuggester = ({ name }: { name: string }) => {
   const t = useTranslation('system');
 
   const { data: matchingEntities } = useEntities({

--- a/frontend/system/src/Admin/EditEntity/components/ExistingItemSuggestor.tsx
+++ b/frontend/system/src/Admin/EditEntity/components/ExistingItemSuggestor.tsx
@@ -1,0 +1,35 @@
+import { useTranslation } from '@common/intl';
+import React from 'react';
+import { useEntities } from 'frontend/system/src/Entities/api';
+import { Link } from 'react-router-dom';
+import { RouteBuilder } from '@common/utils';
+import { AppRoute } from 'frontend/config/src';
+
+export const ExistingNameSuggestor = ({ name }: { name: string }) => {
+  const t = useTranslation('system');
+
+  const { data: matchingEntities } = useEntities({
+    filter: {
+      categories: ['drug', 'consumable', 'vaccine'],
+      match: 'exact',
+      description: name,
+    },
+    first: 1,
+    offset: 0,
+  });
+  const match = matchingEntities?.data[0];
+
+  return match ? (
+    <Link
+      style={{ display: 'block', marginLeft: '10px' }}
+      to={RouteBuilder.create(AppRoute.Admin)
+        .addPart(AppRoute.Edit)
+        .addPart(match.code)
+        .build()}
+    >
+      {t('message.did-you-mean', {
+        suggestion: `${match.description} (${match.code})`,
+      })}
+    </Link>
+  ) : null;
+};

--- a/frontend/system/src/Admin/EditEntity/components/ExistingItemSuggestor.tsx
+++ b/frontend/system/src/Admin/EditEntity/components/ExistingItemSuggestor.tsx
@@ -21,7 +21,7 @@ export const ExistingNameSuggestor = ({ name }: { name: string }) => {
 
   return match ? (
     <Link
-      style={{ display: 'block', marginLeft: '10px' }}
+      style={{ display: 'block', marginLeft: '10px', color: '#003AB1' }}
       to={RouteBuilder.create(AppRoute.Admin)
         .addPart(AppRoute.Edit)
         .addPart(match.code)

--- a/frontend/system/src/Admin/EditEntity/components/VaccineFormTree.tsx
+++ b/frontend/system/src/Admin/EditEntity/components/VaccineFormTree.tsx
@@ -12,7 +12,7 @@ import { EditPropertiesButton } from './EditPropertiesButton';
 import { NameEditField } from './NameEditField';
 import { useConfigurationItems } from '../../Configuration/api';
 import { ConfigurationItemTypeInput } from '@common/types';
-import { ExistingNameSuggestor } from './ExistingItemSuggestor';
+import { ExistingNameSuggester } from './ExistingItemSuggester';
 
 export const VaccineFormTree = ({
   draft,
@@ -140,7 +140,7 @@ export const VaccineFormTree = ({
       </Box>
 
       {/* No initial ids === new item */}
-      {!initialIds.length && <ExistingNameSuggestor name={draft.name} />}
+      {!initialIds.length && <ExistingNameSuggester name={draft.name} />}
 
       {!!draft.components.length && (
         <Typography fontSize="12px">{t('label.components')}</Typography>

--- a/frontend/system/src/Admin/EditEntity/components/VaccineFormTree.tsx
+++ b/frontend/system/src/Admin/EditEntity/components/VaccineFormTree.tsx
@@ -12,6 +12,7 @@ import { EditPropertiesButton } from './EditPropertiesButton';
 import { NameEditField } from './NameEditField';
 import { useConfigurationItems } from '../../Configuration/api';
 import { ConfigurationItemTypeInput } from '@common/types';
+import { ExistingNameSuggestor } from './ExistingItemSuggestor';
 
 export const VaccineFormTree = ({
   draft,
@@ -137,6 +138,9 @@ export const VaccineFormTree = ({
           />
         </Box>
       </Box>
+
+      {/* No initial ids === new item */}
+      {!initialIds.length && <ExistingNameSuggestor name={draft.name} />}
 
       {!!draft.components.length && (
         <Typography fontSize="12px">{t('label.components')}</Typography>


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #509

## Description
<!--- Briefly describe your changes -->

Adds a `Did you mean...` suggester to the new item forms, which links to the edit page for that item:
<img width="517" alt="Screenshot 2024-01-23 at 8 56 00 AM" src="https://github.com/msupply-foundation/unified-codes/assets/55115239/86db9e4a-4b1b-4965-a741-916916ce5991">

Not sure whether to debounce the display of the suggestion a little?