### PR TITLE
558 allow querying property config items when unauthenticated

### DIFF
--- a/backend/graphql/configuration/src/lib.rs
+++ b/backend/graphql/configuration/src/lib.rs
@@ -45,17 +45,8 @@ impl ConfigurationQueries {
         &self,
         ctx: &Context<'_>,
     ) -> Result<PropertyConfigurationItemsResponse> {
-        let user = validate_auth(
-            ctx,
-            &ResourceAccessRequest {
-                resource: Resource::MutateUniversalCodes,
-            },
-        )?;
-
-        let service_context = ctx.service_context(Some(&user))?;
-
-        let result = service_context
-            .service_provider
+        let result = ctx
+            .service_provider()
             .configuration_service
             .property_configuration_items()
             .await?;


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #558 

## Description
<!--- Briefly describe your changes -->

Removes MutateUniversalCodes auth check on queries for property config items, so they are queryable when unauthenticated:

<img width="534" alt="Screenshot 2024-01-30 at 10 37 14 AM" src="https://github.com/msupply-foundation/unified-codes/assets/55115239/41d2b837-3323-4852-af6f-5aa88b4fa11e">


