### PR TITLE
551 duplicate names in dataloaded data

### DIFF
--- a/data-loader/data/v2/drugs.csv
+++ b/data-loader/data/v2/drugs.csv
@@ -645,7 +645,7 @@ Isoniazid/Pyrazinamide/Rifampicin,,0869a14e/7b75ca3c/71e4d8ea,Oral,Tablet,,50mg/
 Isoniazid/Pyrazinamide/Rifampicin,,0869a14e/7b75ca3c/71e4d8ea,Oral,Tablet,,75mg/400mg/150mg,,,,,,,933f3f00,27909727,6a561b00,12c87200,,4682b4bf,,,,,,,214662,6.2.5,6.2.5,,,51162101,,,,,,,,,,,,,
 Isoniazid/Rifampicin,,0869a14e/71e4d8ea,Oral,Tablet,,150mg/150mg,,,,,,,933f3f00,88eff367,738d6d00,b2ea7c00,,4686d4bf,,,,,,,106876,6.25,,10589501000116106,,51162103,,,,,,,,,,,,,
 Isoniazid/Rifampicin,,0869a14e/71e4d8ea,Oral,Tablet,,150mg/300mg,,,,,,,933f3f00,88eff367,738d6d00,b2ea7c00,,468a44bf,,,,,,,106876,6.2.5,6.2.5,10589501000116106,10589531000116102,51162103,,,,,,,,,,,,,
-Isoniazid/Rifampicin,,0869a14e/71e4d8ea,Oral,Tablet,,50mg/75mg,,,,,,,933f3f00,5aacb54c,102e7d00,75474c00,,47c2c43e,,,,,,,106876,6.2.5,6.2.5,10589501000116106,,51162103,,,,,,,,,,,,,
+Isoniazid/Rifampicin,,0869a14e/71e4d8ea,Oral,Tablet,,50mg/75mg,,,,,,,933f3f00,88eff367,738d6d00,b2ea7c00,,47c2c43e,,,,,,,106876,6.2.5,6.2.5,10589501000116106,,51162103,,,,,,,,,,,,,
 Isoniazid/Rifampicin,,0869a14e/71e4d8ea,Oral,Tablet,,60mg/60mg,,,,,,,933f3f00,88eff367,738d6d00,b2ea7c00,,468d54bf,,,,,,,106876,6.2.5,,10589501000116106,,51162103,,,,,,,,,,,,,
 Isoniazid/Rifampicin,,0869a14e/71e4d8ea,Oral,Tablet,,75mg/150mg,,,,,,,933f3f00,88eff367,738d6d00,b2ea7c00,,469064bf,,,,,,,106876,6.2.5,6.2.5,10589501000116106,,51162103,,,,,,,,,,,,,
 Isopropyl Alcohol,,,Topical,Solution,,75%,1000mL,,,,,,933f3f00,4f94b8b9,47f90900,f717a800,,2ef7cb00,a7a36200,,,,,,797541,15.2,15.2,10354241000116101,,51471901,,,,,,,,,,,,,

--- a/data-loader/data/v2/drugs.csv
+++ b/data-loader/data/v2/drugs.csv
@@ -641,7 +641,7 @@ Isoniazid,,,Oral,Solution,,10mg per mL,5mL,,,,,,933f3f00,0869a14e,db7f4e00,17d8d
 Isoniazid,,,Oral,Tablet,,100mg,,,,,,,933f3f00,0869a14e,db7f4e00,8ab83800,,471f243e,,,,,,,6038,6.2.5,6.2.5,10354131000116102,10354151000116107,51281514,,,,,,,,,,,,,
 Isoniazid,,,Oral,Tablet,,300mg,,,,,,,933f3f00,0869a14e,db7f4e00,8ab83800,,4726043e,,,,,,,6038,6.2.5,6.2.5,10354131000116102,,51281514,,,,,,,,,,,,,
 Isoniazid/Pyrazinamide/Rifampicin,,0869a14e/7b75ca3c/71e4d8ea,Oral,Tablet,,150mg/500mg/150mg,,,,,,,933f3f00,27909727,6a561b00,12c87200,,467be4bf,,,,,,,214662,6.2.5,,,,51162101,,,,,,,,,,,,,
-Isoniazid/Pyrazinamide/Rifampicin,,0869a14e/7b75ca3c/71e4d8ea,Oral,Tablet,,50mg/150mg/75mg,,,,,,,933f3f00,11a9a899,6ff8df00,f1f02600,,47ca443e,,,,,,,214662,6.2.5,6.2.5,,,51162101,,,,,,,,,,,,,
+Isoniazid/Pyrazinamide/Rifampicin,,0869a14e/7b75ca3c/71e4d8ea,Oral,Tablet,,50mg/150mg/75mg,,,,,,,933f3f00,27909727,6a561b00,12c87200,,47ca443e,,,,,,,214662,6.2.5,6.2.5,,,51162101,,,,,,,,,,,,,
 Isoniazid/Pyrazinamide/Rifampicin,,0869a14e/7b75ca3c/71e4d8ea,Oral,Tablet,,75mg/400mg/150mg,,,,,,,933f3f00,27909727,6a561b00,12c87200,,4682b4bf,,,,,,,214662,6.2.5,6.2.5,,,51162101,,,,,,,,,,,,,
 Isoniazid/Rifampicin,,0869a14e/71e4d8ea,Oral,Tablet,,150mg/150mg,,,,,,,933f3f00,88eff367,738d6d00,b2ea7c00,,4686d4bf,,,,,,,106876,6.25,,10589501000116106,,51162103,,,,,,,,,,,,,
 Isoniazid/Rifampicin,,0869a14e/71e4d8ea,Oral,Tablet,,150mg/300mg,,,,,,,933f3f00,88eff367,738d6d00,b2ea7c00,,468a44bf,,,,,,,106876,6.2.5,6.2.5,10589501000116106,10589531000116102,51162103,,,,,,,,,,,,,


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #551 

## Description
Two products had the same product name but different codes, this seems to be the case all the way back to 4.3 version spreadsheets.
I've updated to use one (effectively deleting a code, but unlikely to be being used anywhere)

Wrote a quick python script to check for others product name code miss matches, but seems ok.
