### PR TITLE
fix entity update button clickability

### DIFF
--- a/frontend/common/src/ui/components/buttons/standard/ButtonWithIcon.tsx
+++ b/frontend/common/src/ui/components/buttons/standard/ButtonWithIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ButtonProps, Tooltip } from '@mui/material';
+import { Box, ButtonProps, Tooltip } from '@mui/material';
 import { ShrinkableBaseButton } from './ShrinkableBaseButton';
 import { useIsScreen } from '@common/hooks';
 
@@ -41,23 +41,25 @@ export const ButtonWithIcon: React.FC<ButtonWithIconProps> = ({
   const text = shrink ? null : label;
 
   return (
-    <Tooltip title={title}>
-      <span>
-        <ShrinkableBaseButton
-          disabled={disabled}
-          shrink={shrink}
-          onClick={onClick}
-          variant={variant}
-          color={color}
-          size="small"
-          startIcon={startIcon}
-          aria-label={label}
-          {...buttonProps}
-        >
-          {centeredIcon}
-          {text}
-        </ShrinkableBaseButton>
-      </span>
-    </Tooltip>
+    <span>
+      <ShrinkableBaseButton
+        disabled={disabled}
+        shrink={shrink}
+        onClick={onClick}
+        variant={variant}
+        color={color}
+        size="small"
+        startIcon={startIcon}
+        aria-label={label}
+        {...buttonProps}
+      >
+        <Tooltip title={title}>
+          <Box>
+            {centeredIcon}
+            {text}
+          </Box>
+        </Tooltip>
+      </ShrinkableBaseButton>
+    </span>
   );
 };


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #565 

## Description
<!--- Briefly describe your changes -->

Moves the tooltip component inside the button component, so the button is still fully clickable even when the tooltip renders.