### PR TITLE
446 store browsing categories in URL

### DIFF
--- a/frontend/system/src/Entities/ListView.tsx
+++ b/frontend/system/src/Entities/ListView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslation } from '@common/intl';
 import {
   AppBarContentPortal,
@@ -10,7 +10,7 @@ import {
   ToggleButton,
   Stack,
 } from '@common/ui';
-import { useQueryParamsState } from '@common/hooks';
+import { useQueryParamsState, useUrlQuery } from '@common/hooks';
 import { EntityRowFragment, useEntities } from './api';
 import { ToggleButtonGroup } from '@mui/material';
 import { useNavigate } from 'react-router';
@@ -27,6 +27,8 @@ export const ListView = () => {
       initialSort: { key: 'description', dir: 'asc' },
     });
 
+  const { urlQuery, updateQuery } = useUrlQuery();
+
   const { sortBy, page, offset, first } = queryParams;
 
   const columns = useColumns<EntityRowFragment>(
@@ -39,7 +41,7 @@ export const ListView = () => {
     [sortBy, updateSortQuery]
   );
 
-  const [categories, setCategories] = useState<string[]>([]);
+  const categories: string[] = urlQuery.categories ?? [];
 
   const searchFilter = filter.filterBy?.['search'];
   const search = typeof searchFilter === 'string' ? searchFilter : '';
@@ -74,9 +76,9 @@ export const ListView = () => {
 
   const toggleCategory = (category: string) => {
     if (categories.includes(category)) {
-      setCategories(categories.filter(c => c !== category));
+      updateQuery({ ['categories[]']: categories.filter(c => c !== category) });
     } else {
-      setCategories([...categories, category]);
+      updateQuery({ ['categories[]']: [...categories, category] });
     }
   };
 


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #446

## Description
<!--- Briefly describe your changes -->
Manages category filters as url query params so they persist on refresh/navigating back:
<img width="1618" alt="Screenshot 2024-02-02 at 11 54 08 AM" src="https://github.com/msupply-foundation/unified-codes/assets/55115239/d4c98cab-b47b-418d-bff3-9df3afccd79a">


