### PR TITLE
572 escape slashes on entity search

### DIFF
--- a/backend/graphql_v1/universal_codes/src/types/entity_search_input.rs
+++ b/backend/graphql_v1/universal_codes/src/types/entity_search_input.rs
@@ -31,14 +31,15 @@ impl From<EntitySearchInput> for EntitySearchFilter {
     fn from(f: EntitySearchInput) -> Self {
         EntitySearchFilter {
             code: f.code,
-            description: f.description,
+            // many descriptions contain slashes, we need to escape them to provide a valid search input
+            description: f.description.map(|d| d.replace("/", "\\/")),
+            search: f.search.map(|s| s.replace("/", "\\/")),
             order_by: f.order_by.map(|order| EntitySort {
                 descending: order.descending,
                 field: order.field,
             }),
             categories: f.categories,
             r#type: f.r#type,
-            search: f.search,
             r#match: f.r#match,
         }
     }


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #572 

## Description
<!--- Briefly describe your changes -->

Escapes slashes, searches now working as expected:
<img width="504" alt="Screenshot 2024-02-02 at 4 30 58 PM" src="https://github.com/msupply-foundation/unified-codes/assets/55115239/cbf72750-59f7-45f6-8904-132645a67ec9">
<img width="603" alt="Screenshot 2024-02-02 at 4 31 09 PM" src="https://github.com/msupply-foundation/unified-codes/assets/55115239/c85f1307-853a-4c3b-b36c-652ddd6f410e">


